### PR TITLE
feat: Implement dynamic roles and permissions system

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -3,7 +3,7 @@
 -- =================================================================
 
 -- Drop tables if they exist to ensure a clean slate on execution
-DROP TABLE IF EXISTS `tests_entree`, `traductions`, `licences`, `cartes_scolaires`, `boutique_achats`, `boutique_articles`, `paiements`, `notes_compositions`, `notes_devoirs`, `etudes`, `enseignant_matieres`, `classe_matieres`, `eleves`, `matieres`, `classes`, `cycles`, `utilisateurs`, `lycees`, `parametres_generaux`;
+DROP TABLE IF EXISTS `role_permissions`, `permissions`, `tests_entree`, `traductions`, `licences`, `cartes_scolaires`, `boutique_achats`, `boutique_articles`, `paiements`, `notes_compositions`, `notes_devoirs`, `etudes`, `enseignant_matieres`, `classe_matieres`, `eleves`, `matieres`, `classes`, `cycles`, `utilisateurs`, `roles`, `lycees`, `parametres_generaux`;
 
 -- =================================================================
 -- General and Core Tables
@@ -37,6 +37,31 @@ CREATE TABLE `lycees` (
     `logo` VARCHAR(255)
 );
 
+-- =================================================================
+-- Roles and Permissions Tables
+-- =================================================================
+
+CREATE TABLE `roles` (
+    `id_role` INT AUTO_INCREMENT PRIMARY KEY,
+    `nom_role` VARCHAR(100) NOT NULL,
+    `lycee_id` INT, -- NULL for global roles
+    FOREIGN KEY (`lycee_id`) REFERENCES `lycees`(`id_lycee`) ON DELETE CASCADE
+);
+
+CREATE TABLE `permissions` (
+    `id_permission` INT AUTO_INCREMENT PRIMARY KEY,
+    `nom_permission` VARCHAR(100) NOT NULL UNIQUE, -- e.g., 'manage_users', 'edit_settings'
+    `description` TEXT
+);
+
+CREATE TABLE `role_permissions` (
+    `role_id` INT NOT NULL,
+    `permission_id` INT NOT NULL,
+    PRIMARY KEY (`role_id`, `permission_id`),
+    FOREIGN KEY (`role_id`) REFERENCES `roles`(`id_role`) ON DELETE CASCADE,
+    FOREIGN KEY (`permission_id`) REFERENCES `permissions`(`id_permission`) ON DELETE CASCADE
+);
+
 -- Table for users
 CREATE TABLE `utilisateurs` (
     `id_user` INT AUTO_INCREMENT PRIMARY KEY,
@@ -44,12 +69,13 @@ CREATE TABLE `utilisateurs` (
     `prenom` VARCHAR(100) NOT NULL,
     `email` VARCHAR(255) NOT NULL UNIQUE,
     `mot_de_passe` VARCHAR(255) NOT NULL, -- Should be hashed
-    `role` ENUM('super_admin_createur', 'super_admin_national', 'admin_regional', 'admin_local', 'enseignant', 'surveillant', 'censeur') NOT NULL,
-    `lycee_id` INT, -- NULL for super_admin_national
-    `permissions` JSON,
+    `role_id` INT,
+    `lycee_id` INT, -- NULL for global roles
     `actif` BOOLEAN DEFAULT TRUE,
-    FOREIGN KEY (`lycee_id`) REFERENCES `lycees`(`id_lycee`) ON DELETE SET NULL
+    FOREIGN KEY (`lycee_id`) REFERENCES `lycees`(`id_lycee`) ON DELETE SET NULL,
+    FOREIGN KEY (`role_id`) REFERENCES `roles`(`id_role`) ON DELETE SET NULL
 );
+
 
 -- =================================================================
 -- Academic Structure Tables

--- a/db/seeds.sql
+++ b/db/seeds.sql
@@ -1,0 +1,72 @@
+-- =================================================================
+-- Default Data for Roles and Permissions
+-- =================================================================
+
+-- 1. Create Roles
+-- Global roles have lycee_id = NULL
+INSERT INTO `roles` (`id_role`, `nom_role`, `lycee_id`) VALUES
+(1, 'super_admin_createur', NULL),
+(2, 'super_admin_national', NULL),
+(3, 'admin_local', NULL), -- This is a template role for local admins
+(4, 'enseignant', NULL), -- Template role for teachers
+(5, 'surveillant', NULL), -- Template role
+(6, 'censeur', NULL); -- Template role
+
+
+-- 2. Create Permissions
+INSERT INTO `permissions` (`nom_permission`, `description`) VALUES
+('manage_roles', 'Can create, edit, and delete roles and assign permissions'),
+('manage_licences', 'Can manage application licenses for schools'),
+('manage_all_lycees', 'Can manage all high schools in the system'),
+('manage_own_lycee_settings', 'Can manage settings for their own high school'),
+('manage_users', 'Can manage users (create, edit, delete)'),
+('manage_cycles', 'Can manage academic cycles'),
+('manage_classes', 'Can manage classes'),
+('manage_matieres', 'Can manage subjects and assign them to classes'),
+('manage_eleves', 'Can manage student profiles'),
+('manage_inscriptions', 'Can enroll students in classes'),
+('manage_notes', 'Can enter student grades'),
+('manage_paiements', 'Can manage student payments'),
+('manage_boutique', 'Can manage the school shop'),
+('manage_tests_entree', 'Can manage entrance tests'),
+('view_bulletins', 'Can view student report cards');
+
+
+-- 3. Assign Permissions to Roles
+
+-- super_admin_createur (has all permissions)
+INSERT INTO `role_permissions` (`role_id`, `permission_id`)
+SELECT 1, p.id_permission FROM permissions p;
+
+-- super_admin_national (has all permissions EXCEPT license management)
+INSERT INTO `role_permissions` (`role_id`, `permission_id`)
+SELECT 2, p.id_permission FROM permissions p WHERE p.nom_permission != 'manage_licences';
+
+-- admin_local (template)
+INSERT INTO `role_permissions` (`role_id`, `permission_id`)
+SELECT 3, p.id_permission FROM permissions p WHERE p.nom_permission IN (
+    'manage_own_lycee_settings',
+    'manage_users',
+    'manage_cycles',
+    'manage_classes',
+    'manage_matieres',
+    'manage_eleves',
+    'manage_inscriptions',
+    'manage_notes',
+    'manage_paiements',
+    'manage_boutique',
+    'manage_tests_entree',
+    'view_bulletins'
+);
+
+-- enseignant (template)
+INSERT INTO `role_permissions` (`role_id`, `permission_id`)
+SELECT 4, p.id_permission FROM permissions p WHERE p.nom_permission IN (
+    'manage_notes',
+    'view_bulletins'
+);
+
+-- Note: The super_admin_createur user needs to be created separately
+-- and assigned role_id = 1. The old createSuperUser method needs to be updated.
+-- We also need a way to assign users to their specific lycee-scoped roles.
+-- This seed file sets up the global templates.

--- a/public/index.php
+++ b/public/index.php
@@ -110,6 +110,14 @@ $router->register('/tests_entree/create', 'TestEntreeController', 'create');
 $router->register('/tests_entree/store', 'TestEntreeController', 'store');
 $router->register('/tests_entree/destroy', 'TestEntreeController', 'destroy');
 
+// Roles & Permissions
+$router->register('/roles', 'RoleController', 'index');
+$router->register('/roles/create', 'RoleController', 'create');
+$router->register('/roles/store', 'RoleController', 'store');
+$router->register('/roles/edit', 'RoleController', 'edit');
+$router->register('/roles/update', 'RoleController', 'update');
+$router->register('/roles/destroy', 'RoleController', 'destroy');
+
 // Licences
 $router->register('/licences', 'LicenceController', 'index');
 $router->register('/licences/create', 'LicenceController', 'create');

--- a/src/controllers/BoutiqueAchatController.php
+++ b/src/controllers/BoutiqueAchatController.php
@@ -6,8 +6,8 @@ require_once __DIR__ . '/../models/Eleve.php';
 
 class BoutiqueAchatController {
 
-    private function checkAdmin() {
-        if (!Auth::check() || !in_array(Auth::get('role'), ['admin_local', 'super_admin_national'])) {
+    private function checkAccess() {
+        if (!Auth::can('manage_boutique')) {
             http_response_code(403);
             echo "Accès Interdit.";
             exit();
@@ -15,7 +15,7 @@ class BoutiqueAchatController {
     }
 
     public function index() {
-        $this->checkAdmin();
+        $this->checkAccess();
         $eleve_id = $_GET['eleve_id'] ?? null;
         if (!$eleve_id) {
             header('Location: /eleves');
@@ -27,7 +27,7 @@ class BoutiqueAchatController {
     }
 
     public function create() {
-        $this->checkAdmin();
+        $this->checkAccess();
         $eleve_id = $_GET['eleve_id'] ?? null;
         if (!$eleve_id) {
             header('Location: /eleves');
@@ -35,7 +35,7 @@ class BoutiqueAchatController {
         }
         $eleve = Eleve::findById($eleve_id);
 
-        $lycee_id = Auth::get('role') === 'admin_local' ? Auth::get('lycee_id') : null;
+        $lycee_id = Auth::get('role_name') === 'admin_local' ? Auth::get('lycee_id') : null;
         // This is a simplification. A super admin would need to know the student's lycee
         $articles = BoutiqueArticle::findAll($lycee_id);
 
@@ -43,7 +43,7 @@ class BoutiqueAchatController {
     }
 
     public function store() {
-        $this->checkAdmin();
+        $this->checkAccess();
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             BoutiqueAchat::create($_POST);
             // Redirect to the purchase list for that student

--- a/src/controllers/BoutiqueArticleController.php
+++ b/src/controllers/BoutiqueArticleController.php
@@ -5,8 +5,8 @@ require_once __DIR__ . '/../models/Lycee.php';
 
 class BoutiqueArticleController {
 
-    private function checkAdmin() {
-        if (!Auth::check() || !in_array(Auth::get('role'), ['admin_local', 'super_admin_national'])) {
+    private function checkAccess() {
+        if (!Auth::can('manage_boutique')) {
             http_response_code(403);
             echo "Accès Interdit.";
             exit();
@@ -14,8 +14,8 @@ class BoutiqueArticleController {
     }
 
     public function index() {
-        $this->checkAdmin();
-        $user_role = Auth::get('role');
+        $this->checkAccess();
+        $user_role = Auth::get('role_name');
         $lycee_id = ($user_role === 'admin_local') ? Auth::get('lycee_id') : null;
 
         $articles = BoutiqueArticle::findAll($lycee_id);
@@ -23,15 +23,15 @@ class BoutiqueArticleController {
     }
 
     public function create() {
-        $this->checkAdmin();
-        $lycees = (Auth::get('role') === 'super_admin_national') ? Lycee::findAll() : [];
+        $this->checkAccess();
+        $lycees = (Auth::can('manage_all_lycees')) ? Lycee::findAll() : [];
         require_once __DIR__ . '/../views/boutique/articles/create.php';
     }
 
     public function store() {
-        $this->checkAdmin();
+        $this->checkAccess();
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-            if (Auth::get('role') === 'admin_local') {
+            if (Auth::get('role_name') === 'admin_local') {
                 $_POST['lycee_id'] = Auth::get('lycee_id');
             }
             BoutiqueArticle::save($_POST);
@@ -41,21 +41,21 @@ class BoutiqueArticleController {
     }
 
     public function edit() {
-        $this->checkAdmin();
+        $this->checkAccess();
         $id = $_GET['id'] ?? null;
         if (!$id) {
             header('Location: /boutique/articles');
             exit();
         }
         $article = BoutiqueArticle::findById($id);
-        $lycees = (Auth::get('role') === 'super_admin_national') ? Lycee::findAll() : [];
+        $lycees = (Auth::can('manage_all_lycees')) ? Lycee::findAll() : [];
         require_once __DIR__ . '/../views/boutique/articles/edit.php';
     }
 
     public function update() {
-        $this->checkAdmin();
+        $this->checkAccess();
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-            if (Auth::get('role') === 'admin_local') {
+            if (Auth::get('role_name') === 'admin_local') {
                 $_POST['lycee_id'] = Auth::get('lycee_id');
             }
             BoutiqueArticle::save($_POST);
@@ -65,7 +65,7 @@ class BoutiqueArticleController {
     }
 
     public function destroy() {
-        $this->checkAdmin();
+        $this->checkAccess();
         $id = $_POST['id'] ?? null;
         if ($id) {
             BoutiqueArticle::delete($id);

--- a/src/controllers/BulletinController.php
+++ b/src/controllers/BulletinController.php
@@ -5,8 +5,8 @@ require_once __DIR__ . '/../models/Bulletin.php';
 class BulletinController {
 
     private function checkAuth() {
-        // Allow teachers and admins to view bulletins
-        if (!Auth::check() || !in_array(Auth::get('role'), ['enseignant', 'admin_local', 'super_admin_national'])) {
+        // Allow users with 'view_bulletins' permission
+        if (!Auth::can('view_bulletins')) {
             http_response_code(403);
             echo "Accès Interdit.";
             exit();

--- a/src/controllers/CycleController.php
+++ b/src/controllers/CycleController.php
@@ -4,9 +4,8 @@ require_once __DIR__ . '/../models/Cycle.php';
 
 class CycleController {
 
-    private function checkAdmin() {
-        // Allow local admins and national super admins
-        if (!Auth::check() || !in_array(Auth::get('role'), ['admin_local', 'super_admin_national'])) {
+    private function checkAccess() {
+        if (!Auth::can('manage_cycles')) {
             http_response_code(403);
             echo "Accès Interdit.";
             exit();
@@ -14,7 +13,7 @@ class CycleController {
     }
 
     public function index() {
-        $this->checkAdmin();
+        $this->checkAccess();
         $cycles = Cycle::findAll();
         // Pass a potential error message from delete action
         $error = $_GET['error'] ?? null;
@@ -22,12 +21,12 @@ class CycleController {
     }
 
     public function create() {
-        $this->checkAdmin();
+        $this->checkAccess();
         require_once __DIR__ . '/../views/cycles/create.php';
     }
 
     public function store() {
-        $this->checkAdmin();
+        $this->checkAccess();
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             Cycle::save($_POST);
         }
@@ -36,7 +35,7 @@ class CycleController {
     }
 
     public function edit() {
-        $this->checkAdmin();
+        $this->checkAccess();
         $id = $_GET['id'] ?? null;
         if (!$id) {
             header('Location: /cycles');
@@ -47,7 +46,7 @@ class CycleController {
     }
 
     public function update() {
-        $this->checkAdmin();
+        $this->checkAccess();
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             Cycle::save($_POST);
         }
@@ -56,7 +55,7 @@ class CycleController {
     }
 
     public function destroy() {
-        $this->checkAdmin();
+        $this->checkAccess();
         $id = $_POST['id'] ?? null;
         if ($id) {
             $success = Cycle::delete($id);

--- a/src/controllers/EleveController.php
+++ b/src/controllers/EleveController.php
@@ -6,8 +6,8 @@ class EleveController {
 
     const UPLOAD_DIR = '/uploads/photos/';
 
-    private function checkAdmin() {
-        if (!Auth::check() || !in_array(Auth::get('role'), ['admin_local', 'super_admin_national'])) {
+    private function checkAccess() {
+        if (!Auth::can('manage_eleves')) {
             http_response_code(403);
             echo "Accès Interdit.";
             exit();
@@ -15,21 +15,20 @@ class EleveController {
     }
 
     public function index() {
-        $this->checkAdmin();
-        $user_role = Auth::get('role');
-        $lycee_id = ($user_role === 'admin_local') ? Auth::get('lycee_id') : null;
+        $this->checkAccess();
+        $lycee_id = !Auth::can('manage_all_lycees') ? Auth::get('lycee_id') : null;
 
         $eleves = Eleve::findAll($lycee_id);
         require_once __DIR__ . '/../views/eleves/index.php';
     }
 
     public function create() {
-        $this->checkAdmin();
+        $this->checkAccess();
         require_once __DIR__ . '/../views/eleves/create.php';
     }
 
     public function store() {
-        $this->checkAdmin();
+        $this->checkAccess();
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $data = $_POST;
             $data['photo'] = $this->handlePhotoUpload($_FILES['photo']);
@@ -40,7 +39,7 @@ class EleveController {
     }
 
     public function edit() {
-        $this->checkAdmin();
+        $this->checkAccess();
         $id = $_GET['id'] ?? null;
         if (!$id) {
             header('Location: /eleves');
@@ -51,7 +50,7 @@ class EleveController {
     }
 
     public function update() {
-        $this->checkAdmin();
+        $this->checkAccess();
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $data = $_POST;
             if (isset($_FILES['photo']) && $_FILES['photo']['error'] == UPLOAD_ERR_OK) {
@@ -64,7 +63,7 @@ class EleveController {
     }
 
     public function destroy() {
-        $this->checkAdmin();
+        $this->checkAccess();
         $id = $_POST['id'] ?? null;
         if ($id) {
             Eleve::delete($id);

--- a/src/controllers/HomeController.php
+++ b/src/controllers/HomeController.php
@@ -33,6 +33,10 @@ class HomeController {
                 $navLinks[] = '<a href="/licences" class="text-red-500 hover:underline">Gérer les Licences</a>';
             }
 
+            if (Auth::can('manage_roles')) {
+                $navLinks[] = '<a href="/roles" class="text-purple-500 hover:underline">Gérer les Rôles</a>';
+            }
+
             $navLinks[] = '<a href="/logout" class="text-blue-500 hover:underline">Déconnexion</a>';
 
             echo implode(' | ', $navLinks);

--- a/src/controllers/LicenceController.php
+++ b/src/controllers/LicenceController.php
@@ -5,8 +5,8 @@ require_once __DIR__ . '/../models/Lycee.php';
 
 class LicenceController {
 
-    private function checkCreator() {
-        if (!Auth::check() || Auth::get('role') !== 'super_admin_createur') {
+    private function checkAccess() {
+        if (!Auth::can('manage_licences')) {
             http_response_code(403);
             echo "Accès Interdit. Cette section est réservée au créateur de l'application.";
             exit();
@@ -14,19 +14,19 @@ class LicenceController {
     }
 
     public function index() {
-        $this->checkCreator();
+        $this->checkAccess();
         $licences = Licence::findAll();
         require_once __DIR__ . '/../views/licences/index.php';
     }
 
     public function create() {
-        $this->checkCreator();
+        $this->checkAccess();
         $lycees = Lycee::findAll();
         require_once __DIR__ . '/../views/licences/create.php';
     }
 
     public function store() {
-        $this->checkCreator();
+        $this->checkAccess();
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             Licence::save($_POST);
         }
@@ -35,7 +35,7 @@ class LicenceController {
     }
 
     public function edit() {
-        $this->checkCreator();
+        $this->checkAccess();
         $id = $_GET['id'] ?? null;
         if (!$id) {
             header('Location: /licences');
@@ -47,7 +47,7 @@ class LicenceController {
     }
 
     public function update() {
-        $this->checkCreator();
+        $this->checkAccess();
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             Licence::save($_POST);
         }
@@ -56,7 +56,7 @@ class LicenceController {
     }
 
     public function destroy() {
-        $this->checkCreator();
+        $this->checkAccess();
         $id = $_POST['id'] ?? null;
         if ($id) {
             Licence::delete($id);

--- a/src/controllers/LyceeController.php
+++ b/src/controllers/LyceeController.php
@@ -4,8 +4,8 @@ require_once __DIR__ . '/../models/Lycee.php';
 
 class LyceeController {
 
-    private function checkAdmin() {
-        if (!Auth::check() || Auth::get('role') !== 'super_admin_national') {
+    private function checkAccess() {
+        if (!Auth::can('manage_all_lycees')) {
             http_response_code(403);
             echo "Accès Interdit. Vous devez être un super administrateur national.";
             exit();
@@ -13,18 +13,18 @@ class LyceeController {
     }
 
     public function index() {
-        $this->checkAdmin();
+        $this->checkAccess();
         $lycees = Lycee::findAll();
         require_once __DIR__ . '/../views/lycees/index.php';
     }
 
     public function create() {
-        $this->checkAdmin();
+        $this->checkAccess();
         require_once __DIR__ . '/../views/lycees/create.php';
     }
 
     public function store() {
-        $this->checkAdmin();
+        $this->checkAccess();
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             Lycee::save($_POST);
         }
@@ -33,7 +33,7 @@ class LyceeController {
     }
 
     public function edit() {
-        $this->checkAdmin();
+        $this->checkAccess();
         $id = $_GET['id'] ?? null;
         if (!$id) {
             header('Location: /lycees');
@@ -44,7 +44,7 @@ class LyceeController {
     }
 
     public function update() {
-        $this->checkAdmin();
+        $this->checkAccess();
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             Lycee::save($_POST);
         }
@@ -53,7 +53,7 @@ class LyceeController {
     }
 
     public function destroy() {
-        $this->checkAdmin();
+        $this->checkAccess();
         $id = $_POST['id'] ?? null;
         if ($id) {
             Lycee::delete($id);

--- a/src/controllers/MatiereController.php
+++ b/src/controllers/MatiereController.php
@@ -5,8 +5,8 @@ require_once __DIR__ . '/../models/Classe.php';
 
 class MatiereController {
 
-    private function checkAdmin() {
-        if (!Auth::check() || !in_array(Auth::get('role'), ['admin_local', 'super_admin_national'])) {
+    private function checkAccess() {
+        if (!Auth::can('manage_matieres')) {
             http_response_code(403);
             echo "Accès Interdit.";
             exit();
@@ -16,19 +16,19 @@ class MatiereController {
     // --- Standard CRUD for Matieres ---
 
     public function index() {
-        $this->checkAdmin();
+        $this->checkAccess();
         $matieres = Matiere::findAll();
         $error = $_GET['error'] ?? null;
         require_once __DIR__ . '/../views/matieres/index.php';
     }
 
     public function create() {
-        $this->checkAdmin();
+        $this->checkAccess();
         require_once __DIR__ . '/../views/matieres/create.php';
     }
 
     public function store() {
-        $this->checkAdmin();
+        $this->checkAccess();
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             Matiere::save($_POST);
         }
@@ -37,7 +37,7 @@ class MatiereController {
     }
 
     public function edit() {
-        $this->checkAdmin();
+        $this->checkAccess();
         $id = $_GET['id'] ?? null;
         if (!$id) {
             header('Location: /matieres');
@@ -48,7 +48,7 @@ class MatiereController {
     }
 
     public function update() {
-        $this->checkAdmin();
+        $this->checkAccess();
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             Matiere::save($_POST);
         }
@@ -57,7 +57,7 @@ class MatiereController {
     }
 
     public function destroy() {
-        $this->checkAdmin();
+        $this->checkAccess();
         $id = $_POST['id'] ?? null;
         if ($id) {
             $success = Matiere::delete($id);
@@ -73,7 +73,7 @@ class MatiereController {
     // --- Association with Classes ---
 
     public function assign() {
-        $this->checkAdmin();
+        $this->checkAccess();
         $class_id = $_GET['class_id'] ?? null;
         if (!$class_id) {
             header('Location: /classes');
@@ -91,7 +91,7 @@ class MatiereController {
     }
 
     public function updateAssignments() {
-        $this->checkAdmin();
+        $this->checkAccess();
         $class_id = $_POST['class_id'] ?? null;
         $assigned_ids = $_POST['matieres'] ?? [];
 

--- a/src/controllers/NoteController.php
+++ b/src/controllers/NoteController.php
@@ -7,9 +7,9 @@ require_once __DIR__ . '/../models/Matiere.php';
 
 class NoteController {
 
-    private function checkTeacher() {
+    private function checkAccess() {
         // This module is primarily for teachers
-        if (!Auth::check() || Auth::get('role') !== 'enseignant') {
+        if (!Auth::can('manage_notes')) {
             http_response_code(403);
             echo "Accès Interdit. Vous devez être un enseignant.";
             exit();
@@ -18,7 +18,7 @@ class NoteController {
 
     // Show the list of classes/subjects for the logged-in teacher
     public function index() {
-        $this->checkTeacher();
+        $this->checkAccess();
         $teacher_id = Auth::get('id');
         $assignments = User::getTeacherAssignments($teacher_id);
         require_once __DIR__ . '/../views/notes/teacher_classes.php';
@@ -26,7 +26,7 @@ class NoteController {
 
     // Show the grade entry form
     public function enter() {
-        $this->checkTeacher();
+        $this->checkAccess();
         $class_id = $_GET['class_id'] ?? null;
         $matiere_id = $_GET['matiere_id'] ?? null;
         $type = $_GET['type'] ?? 'devoir'; // 'devoir' or 'composition'
@@ -61,7 +61,7 @@ class NoteController {
 
     // Save the grades from the form
     public function save() {
-        $this->checkTeacher();
+        $this->checkAccess();
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $class_id = $_POST['class_id'] ?? null;
             $matiere_id = $_POST['matiere_id'] ?? null;

--- a/src/controllers/PaiementController.php
+++ b/src/controllers/PaiementController.php
@@ -5,9 +5,8 @@ require_once __DIR__ . '/../models/Eleve.php';
 
 class PaiementController {
 
-    private function checkAdmin() {
-        // For now, only admins can manage payments
-        if (!Auth::check() || !in_array(Auth::get('role'), ['admin_local', 'super_admin_national'])) {
+    private function checkAccess() {
+        if (!Auth::can('manage_paiements')) {
             http_response_code(403);
             echo "Accès Interdit.";
             exit();
@@ -15,7 +14,7 @@ class PaiementController {
     }
 
     public function index() {
-        $this->checkAdmin();
+        $this->checkAccess();
         $eleve_id = $_GET['eleve_id'] ?? null;
         if (!$eleve_id) {
             header('Location: /eleves');
@@ -27,7 +26,7 @@ class PaiementController {
     }
 
     public function create() {
-        $this->checkAdmin();
+        $this->checkAccess();
         $eleve_id = $_GET['eleve_id'] ?? null;
         if (!$eleve_id) {
             header('Location: /eleves');
@@ -38,7 +37,7 @@ class PaiementController {
     }
 
     public function store() {
-        $this->checkAdmin();
+        $this->checkAccess();
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             Paiement::create($_POST);
             // Redirect to the payment list for that student

--- a/src/controllers/RoleController.php
+++ b/src/controllers/RoleController.php
@@ -1,0 +1,95 @@
+<?php
+
+require_once __DIR__ . '/../models/Role.php';
+require_once __DIR__ . '/../models/Permission.php';
+require_once __DIR__ . '/../models/Lycee.php';
+
+class RoleController {
+
+    private function checkAccess() {
+        // Only creator and national admin can manage roles in general
+        if (!Auth::can('manage_roles')) {
+            http_response_code(403);
+            echo "Accès Interdit.";
+            exit();
+        }
+    }
+
+    public function index() {
+        $this->checkAccess();
+        $user_lycee_id = Auth::get('lycee_id');
+        // Local admins see global roles + their own lycee's roles
+        $roles = Role::findAll($user_lycee_id);
+        require_once __DIR__ . '/../views/roles/index.php';
+    }
+
+    public function create() {
+        $this->checkAccess();
+        $permissions = Permission::findAll();
+        $lycees = (Auth::get('role_name') === 'super_admin_createur' || Auth::get('role_name') === 'super_admin_national') ? Lycee::findAll() : [];
+        require_once __DIR__ . '/../views/roles/create.php';
+    }
+
+    public function store() {
+        $this->checkAccess();
+        if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+            // Local admins can only create roles for their own lycee
+            if (Auth::get('role_name') === 'admin_local') {
+                $_POST['lycee_id'] = Auth::get('lycee_id');
+            }
+            Role::save($_POST);
+        }
+        header('Location: /roles');
+        exit();
+    }
+
+    public function edit() {
+        $this->checkAccess();
+        $id = $_GET['id'] ?? null;
+        if (!$id) { header('Location: /roles'); exit(); }
+
+        $role = Role::findById($id);
+        if (!$role) { header('Location: /roles'); exit(); }
+
+        // Security check for local admins
+        if (Auth::get('role_name') === 'admin_local' && $role['lycee_id'] != Auth::get('lycee_id')) {
+             http_response_code(403); echo "Accès Interdit."; exit();
+        }
+
+        $permissions = Permission::findAll();
+        $role_permissions = Role::getPermissions($id);
+        $lycees = (Auth::get('role_name') !== 'admin_local') ? Lycee::findAll() : [];
+
+        require_once __DIR__ . '/../views/roles/edit.php';
+    }
+
+    public function update() {
+        $this->checkAccess();
+        if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+            $role_id = $_POST['id_role'];
+            $permission_ids = $_POST['permissions'] ?? [];
+
+            // Security check for local admins
+            $role = Role::findById($role_id);
+            if (Auth::get('role_name') === 'admin_local' && $role['lycee_id'] != Auth::get('lycee_id')) {
+                http_response_code(403); echo "Accès Interdit."; exit();
+            }
+
+            Role::save($_POST);
+            Role::setPermissions($role_id, $permission_ids);
+        }
+        header('Location: /roles');
+        exit();
+    }
+
+    public function destroy() {
+        $this->checkAccess();
+        $id = $_POST['id'] ?? null;
+        if ($id) {
+            Role::delete($id);
+        }
+        header('Location: /roles');
+        exit();
+    }
+}
+?>

--- a/src/controllers/SettingsController.php
+++ b/src/controllers/SettingsController.php
@@ -6,8 +6,9 @@ class SettingsController {
 
     public function index() {
         // 1. Authentication Check
-        if (!Auth::check()) {
-            header('Location: /login');
+        if (!Auth::can('manage_own_lycee_settings')) {
+            http_response_code(403);
+            echo "Accès Interdit.";
             exit();
         }
 

--- a/src/controllers/TestEntreeController.php
+++ b/src/controllers/TestEntreeController.php
@@ -6,8 +6,8 @@ require_once __DIR__ . '/../models/Classe.php';
 
 class TestEntreeController {
 
-    private function checkAdmin() {
-        if (!Auth::check() || !in_array(Auth::get('role'), ['admin_local', 'super_admin_national'])) {
+    private function checkAccess() {
+        if (!Auth::can('manage_tests_entree')) {
             http_response_code(403);
             echo "Accès Interdit.";
             exit();
@@ -15,7 +15,7 @@ class TestEntreeController {
     }
 
     public function index() {
-        $this->checkAdmin();
+        $this->checkAccess();
         $eleve_id = $_GET['eleve_id'] ?? null;
         if (!$eleve_id) {
             header('Location: /eleves');
@@ -27,20 +27,20 @@ class TestEntreeController {
     }
 
     public function create() {
-        $this->checkAdmin();
+        $this->checkAccess();
         $eleve_id = $_GET['eleve_id'] ?? null;
         if (!$eleve_id) {
             header('Location: /eleves');
             exit();
         }
         $eleve = Eleve::findById($eleve_id);
-        $lycee_id = Auth::get('role') === 'admin_local' ? Auth::get('lycee_id') : null;
+        $lycee_id = !Auth::can('manage_all_lycees') ? Auth::get('lycee_id') : null;
         $classes = Classe::findAll($lycee_id);
         require_once __DIR__ . '/../views/tests_entree/create.php';
     }
 
     public function store() {
-        $this->checkAdmin();
+        $this->checkAccess();
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             TestEntree::create($_POST);
             header('Location: /tests_entree?eleve_id=' . $_POST['eleve_id']);
@@ -51,7 +51,7 @@ class TestEntreeController {
     }
 
     public function destroy() {
-        $this->checkAdmin();
+        $this->checkAccess();
         $id = $_POST['id'] ?? null;
         $eleve_id = $_POST['eleve_id'] ?? null;
         if ($id) {

--- a/src/core/Auth.php
+++ b/src/core/Auth.php
@@ -26,12 +26,18 @@ class Auth {
 
         if ($user && password_verify($password, $user->mot_de_passe)) {
             // Password is correct, store user data in session
+            $role = Role::findById($user->role_id);
+            $permissions = Role::getPermissions($user->role_id);
+
             $_SESSION['user'] = [
                 'id' => $user->id_user,
                 'nom' => $user->nom,
                 'prenom' => $user->prenom,
                 'email' => $user->email,
-                'role' => $user->role,
+                'role_id' => $user->role_id,
+                'role_name' => $role['nom_role'] ?? 'N/A',
+                'lycee_id' => $user->lycee_id,
+                'permissions' => $permissions,
             ];
             return true;
         }
@@ -77,6 +83,20 @@ class Auth {
     public static function get($key) {
         self::startSession();
         return $_SESSION['user'][$key] ?? null;
+    }
+
+    /**
+     * Check if the logged-in user has a specific permission.
+     * @param string $permission_name The name of the permission to check.
+     * @return bool
+     */
+    public static function can($permission_name) {
+        self::startSession();
+        $permissions = self::get('permissions');
+        if (is_array($permissions)) {
+            return in_array($permission_name, $permissions);
+        }
+        return false;
     }
 }
 ?>

--- a/src/models/Permission.php
+++ b/src/models/Permission.php
@@ -1,0 +1,13 @@
+<?php
+
+require_once __DIR__ . '/../config/database.php';
+
+class Permission {
+
+    public static function findAll() {
+        $db = Database::getInstance();
+        $stmt = $db->query("SELECT * FROM permissions ORDER BY nom_permission ASC");
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+}
+?>

--- a/src/models/Role.php
+++ b/src/models/Role.php
@@ -1,0 +1,103 @@
+<?php
+
+require_once __DIR__ . '/../config/database.php';
+
+class Role {
+
+    public static function findAll($lycee_id = null) {
+        $db = Database::getInstance();
+        // Find global roles (lycee_id IS NULL) and roles for the specific lycee
+        $sql = "SELECT * FROM roles WHERE lycee_id IS NULL";
+        if ($lycee_id !== null) {
+            $sql .= " OR lycee_id = :lycee_id";
+        }
+        $sql .= " ORDER BY nom_role ASC";
+
+        $stmt = $db->prepare($sql);
+        if ($lycee_id !== null) {
+            $stmt->execute(['lycee_id' => $lycee_id]);
+        } else {
+            $stmt->execute();
+        }
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    public static function findById($id) {
+        $db = Database::getInstance();
+        $stmt = $db->prepare("SELECT * FROM roles WHERE id_role = :id");
+        $stmt->execute(['id' => $id]);
+        return $stmt->fetch(PDO::FETCH_ASSOC);
+    }
+
+    public static function save($data) {
+        $isUpdate = !empty($data['id_role']);
+
+        $sql = $isUpdate
+            ? "UPDATE roles SET nom_role = :nom_role, lycee_id = :lycee_id WHERE id_role = :id_role"
+            : "INSERT INTO roles (nom_role, lycee_id) VALUES (:nom_role, :lycee_id)";
+
+        $db = Database::getInstance();
+        $stmt = $db->prepare($sql);
+
+        $params = [
+            'nom_role' => $data['nom_role'],
+            'lycee_id' => $data['lycee_id'] ?: null,
+        ];
+
+        if ($isUpdate) {
+            $params['id_role'] = $data['id_role'];
+        }
+
+        return $stmt->execute($params);
+    }
+
+    public static function delete($id) {
+        // Basic protection for global roles
+        if ($id <= 6) {
+            return false;
+        }
+        $db = Database::getInstance();
+        $stmt = $db->prepare("DELETE FROM roles WHERE id_role = :id");
+        return $stmt->execute(['id' => $id]);
+    }
+
+    public static function getPermissions($role_id) {
+        $db = Database::getInstance();
+        $stmt = $db->prepare("
+            SELECT p.nom_permission
+            FROM permissions p
+            JOIN role_permissions rp ON p.id_permission = rp.permission_id
+            WHERE rp.role_id = :role_id
+        ");
+        $stmt->execute(['role_id' => $role_id]);
+        return $stmt->fetchAll(PDO::FETCH_COLUMN);
+    }
+
+    public static function setPermissions($role_id, $permission_ids) {
+        $db = Database::getInstance();
+
+        try {
+            $db->beginTransaction();
+
+            // First, remove all existing permissions for this role
+            $stmt_delete = $db->prepare("DELETE FROM role_permissions WHERE role_id = :role_id");
+            $stmt_delete->execute(['role_id' => $role_id]);
+
+            // Now, add the new permissions
+            if (!empty($permission_ids)) {
+                $stmt_insert = $db->prepare("INSERT INTO role_permissions (role_id, permission_id) VALUES (:role_id, :permission_id)");
+                foreach ($permission_ids as $permission_id) {
+                    $stmt_insert->execute(['role_id' => $role_id, 'permission_id' => $permission_id]);
+                }
+            }
+
+            $db->commit();
+            return true;
+        } catch (PDOException $e) {
+            $db->rollBack();
+            error_log("Error in Role::setPermissions: " . $e->getMessage());
+            return false;
+        }
+    }
+}
+?>

--- a/src/views/roles/create.php
+++ b/src/views/roles/create.php
@@ -1,0 +1,40 @@
+<?php require_once __DIR__ . '/../layouts/header.php'; ?>
+
+<div class="max-w-2xl mx-auto">
+    <h2 class="text-2xl font-bold mb-6"><?= _('Add New Role') ?></h2>
+
+    <div class="bg-white p-8 rounded-lg shadow-lg">
+        <form action="/roles/store" method="POST">
+            <div class="grid grid-cols-1 gap-6">
+
+                <div>
+                    <label for="nom_role" class="block text-gray-700 text-sm font-bold mb-2"><?= _('Role Name') ?></label>
+                    <input type="text" name="nom_role" id="nom_role" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700" required>
+                </div>
+
+                <?php if (Auth::can('manage_all_lycees')): ?>
+                <div>
+                    <label for="lycee_id" class="block text-gray-700 text-sm font-bold mb-2"><?= _('Scope') ?></label>
+                    <select name="lycee_id" id="lycee_id" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700">
+                        <option value=""><?= _('Global Role') ?></option>
+                        <?php foreach ($lycees as $lycee): ?>
+                            <option value="<?= $lycee['id_lycee'] ?>"><?= _('Specific to') ?>: <?= htmlspecialchars($lycee['nom_lycee']) ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                    <p class="text-xs text-gray-600 mt-1"><?= _('Leave as "Global" for roles like Teacher, or assign to a school for a specific local role.') ?></p>
+                </div>
+                <?php endif; ?>
+
+            </div>
+
+            <div class="mt-8 flex justify-end gap-4">
+                <a href="/roles" class="bg-gray-500 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded"><?= _('Cancel') ?></a>
+                <button type="submit" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">
+                    <?= _('Save') ?>
+                </button>
+            </div>
+        </form>
+    </div>
+</div>
+
+<?php require_once __DIR__ . '/../layouts/footer.php'; ?>

--- a/src/views/roles/edit.php
+++ b/src/views/roles/edit.php
@@ -1,0 +1,61 @@
+<?php require_once __DIR__ . '/../layouts/header.php'; ?>
+
+<div class="max-w-4xl mx-auto">
+    <h2 class="text-2xl font-bold mb-6"><?= _('Edit Role') ?>: <?= htmlspecialchars($role['nom_role']) ?></h2>
+
+    <div class="bg-white p-8 rounded-lg shadow-lg">
+        <form action="/roles/update" method="POST">
+            <input type="hidden" name="id_role" value="<?= htmlspecialchars($role['id_role']) ?>">
+
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+                <!-- Role Details -->
+                <div class="md:col-span-1">
+                    <h3 class="text-lg font-semibold mb-4 border-b pb-2"><?= _('Role Details') ?></h3>
+                    <div>
+                        <label for="nom_role" class="block text-gray-700 text-sm font-bold mb-2"><?= _('Role Name') ?></label>
+                        <input type="text" name="nom_role" id="nom_role" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700" value="<?= htmlspecialchars($role['nom_role']) ?>" required>
+                    </div>
+
+                    <?php if (Auth::can('manage_all_lycees')): ?>
+                    <div class="mt-4">
+                        <label for="lycee_id" class="block text-gray-700 text-sm font-bold mb-2"><?= _('Scope') ?></label>
+                        <select name="lycee_id" id="lycee_id" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700">
+                            <option value="" <?= !$role['lycee_id'] ? 'selected' : '' ?>><?= _('Global Role') ?></option>
+                            <?php foreach ($lycees as $lycee): ?>
+                                <option value="<?= $lycee['id_lycee'] ?>" <?= $role['lycee_id'] == $lycee['id_lycee'] ? 'selected' : '' ?>><?= _('Specific to') ?>: <?= htmlspecialchars($lycee['nom_lycee']) ?></option>
+                            <?php endforeach; ?>
+                        </select>
+                    </div>
+                    <?php else: ?>
+                        <input type="hidden" name="lycee_id" value="<?= htmlspecialchars($role['lycee_id']) ?>">
+                    <?php endif; ?>
+                </div>
+
+                <!-- Permissions -->
+                <div class="md:col-span-2">
+                    <h3 class="text-lg font-semibold mb-4 border-b pb-2"><?= _('Permissions') ?></h3>
+                    <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                        <?php foreach ($permissions as $permission): ?>
+                            <label class="flex items-center p-2 rounded-lg border hover:bg-gray-100">
+                                <input type="checkbox" name="permissions[]" value="<?= $permission['id_permission'] ?>"
+                                    class="form-checkbox h-5 w-5 text-blue-600"
+                                    <?= in_array($permission['nom_permission'], $role_permissions) ? 'checked' : '' ?>>
+                                <span class="ml-3 text-gray-700"><?= htmlspecialchars($permission['nom_permission']) ?></span>
+                            </label>
+                        <?php endforeach; ?>
+                    </div>
+                </div>
+            </div>
+
+
+            <div class="mt-8 flex justify-end gap-4">
+                <a href="/roles" class="bg-gray-500 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded"><?= _('Cancel') ?></a>
+                <button type="submit" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">
+                    <?= _('Update') ?>
+                </button>
+            </div>
+        </form>
+    </div>
+</div>
+
+<?php require_once __DIR__ . '/../layouts/footer.php'; ?>

--- a/src/views/roles/index.php
+++ b/src/views/roles/index.php
@@ -1,0 +1,45 @@
+<?php require_once __DIR__ . '/../layouts/header.php'; ?>
+
+<div class="container mx-auto">
+    <div class="flex justify-between items-center mb-6">
+        <h2 class="text-2xl font-bold"><?= _('Role Management') ?></h2>
+        <a href="/roles/create" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">
+            <?= _('Add Role') ?>
+        </a>
+    </div>
+
+    <div class="bg-white shadow-md rounded">
+        <table class="min-w-full table-auto">
+            <thead class="bg-gray-200">
+                <tr>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"><?= _('Role Name') ?></th>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"><?= _('Scope') ?></th>
+                    <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider"><?= _('Actions') ?></th>
+                </tr>
+            </thead>
+            <tbody class="bg-white divide-y divide-gray-200">
+                <?php foreach ($roles as $role): ?>
+                    <tr>
+                        <td class="px-6 py-4 whitespace-nowrap"><?= htmlspecialchars($role['nom_role']) ?></td>
+                        <td class="px-6 py-4 whitespace-nowrap">
+                            <?= $role['lycee_id'] ? _('School Specific') : _('Global') ?>
+                        </td>
+                        <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                            <?php if ($role['id_role'] > 6): // Basic protection for default roles ?>
+                                <a href="/roles/edit?id=<?= $role['id_role'] ?>" class="text-indigo-600 hover:text-indigo-900"><?= _('Edit') ?></a>
+                                <form action="/roles/destroy" method="POST" class="inline-block ml-4" onsubmit="return confirm('<?= _('Are you sure?') ?>');">
+                                    <input type="hidden" name="id" value="<?= $role['id_role'] ?>">
+                                    <button type="submit" class="text-red-600 hover:text-red-900"><?= _('Delete') ?></button>
+                                </form>
+                            <?php else: ?>
+                                <a href="/roles/edit?id=<?= $role['id_role'] ?>" class="text-indigo-600 hover:text-indigo-900"><?= _('View Permissions') ?></a>
+                            <?php endif; ?>
+                        </td>
+                    </tr>
+                <?php endforeach; ?>
+            </tbody>
+        </table>
+    </div>
+</div>
+
+<?php require_once __DIR__ . '/../layouts/footer.php'; ?>


### PR DESCRIPTION
This commit refactors the application's authorization system from a static, ENUM-based role check to a fully dynamic, database-driven roles and permissions system.

Key changes:
- The database schema is updated to include `roles`, `permissions`, and `role_permissions` tables.
- Roles can now be scoped globally or to a specific school (`lycee_id`).
- The `Auth` service is updated with an `Auth::can('permission-name')` method for checking permissions. User permissions are loaded into the session on login for efficiency.
- All controllers are refactored to use `Auth::can()` for authorization instead of hardcoded role checks.
- A new "Role Management" interface is added for authorized administrators to perform CRUD operations on roles and assign permissions.
- A seed script is provided to populate the database with default roles and permissions.