### PR TITLE
fix: Add .htaccess for URL rewriting

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,0 +1,12 @@
+<IfModule mod_rewrite.c>
+    RewriteEngine On
+
+    # Redirect Trailing Slashes If Not A Folder...
+    RewriteCond %{REQUEST_FILENAME} !-d
+    RewriteRule ^(.*)/$ /$1 [L,R=301]
+
+    # Handle Front Controller...
+    RewriteCond %{REQUEST_FILENAME} !-d
+    RewriteCond %{REQUEST_FILENAME} !-f
+    RewriteRule ^ index.php [L]
+</IfModule>


### PR DESCRIPTION
This commit adds a standard `.htaccess` file to the `public/` directory to handle URL rewriting for the front-controller pattern.

This resolves an issue where users would encounter 'Page Not Found' errors when running the application on an Apache server where `mod_rewrite` is enabled but not configured for the project.