### PR TITLE
feat: Implement first-time setup wizard

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -3,6 +3,19 @@
 // Initialize internationalization (i18n)
 require_once __DIR__ . '/../src/core/bootstrap_i18n.php';
 
+// --- First Time Setup Check ---
+require_once __DIR__ . '/../src/models/User.php';
+$national_admin = User::findOneByRoleName('super_admin_national');
+if (!$national_admin) {
+    // If no national admin exists, we must run the setup process.
+    // We allow access only to the setup routes.
+    $uri = strtok($_SERVER['REQUEST_URI'], '?');
+    if (strpos($uri, '/setup') !== 0) {
+        header('Location: /setup');
+        exit();
+    }
+}
+
 // Require necessary files
 require_once __DIR__ . '/../src/core/Router.php';
 require_once __DIR__ . '/../src/core/Auth.php';
@@ -129,6 +142,11 @@ $router->register('/licences/destroy', 'LicenceController', 'destroy');
 // Card Template
 $router->register('/modele-carte/edit', 'ModeleCarteController', 'edit');
 $router->register('/carte/generer', 'CarteController', 'generer');
+
+// Setup
+$router->register('/setup', 'SetupController', 'index');
+$router->register('/setup/choice', 'SetupController', 'processChoice');
+$router->register('/setup/finish', 'SetupController', 'finish');
 
 // Timetable
 $router->register('/emploi-du-temps', 'EmploiDuTempsController', 'index');

--- a/src/controllers/SetupController.php
+++ b/src/controllers/SetupController.php
@@ -1,0 +1,123 @@
+<?php
+
+require_once __DIR__ . '/../models/User.php';
+require_once __DIR__ . '/../models/Lycee.php';
+require_once __DIR__ . '/../models/Role.php';
+require_once __DIR__ . '/../models/ParametresGeneraux.php';
+require_once __DIR__ . '/../models/Permission.php';
+
+
+class SetupController {
+
+    public function index() {
+        // Step 0: Show the choice form
+        require_once __DIR__ . '/../views/setup/step0_choice.php';
+    }
+
+    public function processChoice() {
+        $mode = $_POST['install_mode'] ?? 'single';
+        if ($mode === 'multi') {
+            require_once __DIR__ . '/../views/setup/step1_multi.php';
+        } else {
+            require_once __DIR__ . '/../views/setup/step1_single.php';
+        }
+    }
+
+    public function finish() {
+        if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+            header('Location: /setup');
+            exit();
+        }
+
+        $mode = $_POST['install_mode'] ?? 'single';
+
+        if ($mode === 'multi') {
+            $this->setupMultiSchool($_POST);
+        } else {
+            $this->setupSingleSchool($_POST);
+        }
+
+        // Redirect to login page after setup is complete
+        header('Location: /login');
+        exit();
+    }
+
+    private function setupMultiSchool($data) {
+        // In multi-school mode, we just create the super_admin_national
+        $user_data = [
+            'nom' => $data['nom'],
+            'prenom' => $data['prenom'],
+            'email' => $data['email'],
+            'mot_de_passe' => $data['mot_de_passe'],
+            'role_id' => 2, // Assumes role_id 2 is super_admin_national from seeds
+            'lycee_id' => null,
+            'actif' => 1
+        ];
+        User::save($user_data);
+    }
+
+    private function setupSingleSchool($data) {
+        $db = Database::getInstance();
+        try {
+            $db->beginTransaction();
+
+            // 1. Create the Lycee
+            $lycee_data = [
+                'nom_lycee' => $data['nom_lycee'],
+                'type_lycee' => $data['type_lycee'],
+            ];
+            Lycee::save($lycee_data);
+            $lycee_id = $db->lastInsertId();
+
+            // 2. Create a specific admin role for this Lycee
+            $role_data = [
+                'nom_role' => 'Admin - ' . $data['nom_lycee'],
+                'lycee_id' => $lycee_id
+            ];
+            Role::save($role_data);
+            $role_id = $db->lastInsertId();
+
+            // 3. Assign permissions to this new role (e.g., copy from template role 3)
+            $template_permissions = Role::getPermissions(3); // Get perms from admin_local template
+            $perm_ids = [];
+            foreach($template_permissions as $p_name) {
+                // This is inefficient, a better way would be a direct SQL copy or a findByName method
+                // For now, this will work.
+                $stmt = $db->prepare("SELECT id_permission FROM permissions WHERE nom_permission = :p_name");
+                $stmt->execute(['p_name' => $p_name]);
+                $p_id = $stmt->fetchColumn();
+                if ($p_id) $perm_ids[] = $p_id;
+            }
+            Role::setPermissions($role_id, $perm_ids);
+
+            // 4. Create the admin user for the Lycee
+            $user_data = [
+                'nom' => $data['admin_nom'],
+                'prenom' => $data['admin_prenom'],
+                'email' => $data['admin_email'],
+                'mot_de_passe' => $data['admin_pass'],
+                'role_id' => $role_id,
+                'lycee_id' => $lycee_id,
+                'actif' => 1
+            ];
+            User::save($user_data);
+
+            // 5. Save general settings
+            $settings_data = [
+                'lycee_id' => $lycee_id,
+                'nom_lycee' => $data['nom_lycee'],
+                'type_lycee' => $data['type_lycee'],
+                'annee_academique' => $data['annee_academique'],
+                'modalite_paiement' => 'avant_inscription', // Default
+            ];
+            ParametresGeneraux::save($settings_data);
+
+            $db->commit();
+        } catch (Exception $e) {
+            $db->rollBack();
+            // In a real app, show a proper error page
+            die("Setup failed: " . $e->getMessage());
+        }
+    }
+}
+?>

--- a/src/models/ParametresGeneraux.php
+++ b/src/models/ParametresGeneraux.php
@@ -1,0 +1,37 @@
+<?php
+
+require_once __DIR__ . '/../config/database.php';
+
+class ParametresGeneraux {
+
+    public static function getByLyceeId($lycee_id) {
+        $db = Database::getInstance();
+        $stmt = $db->prepare("SELECT * FROM parametres_generaux WHERE lycee_id = :lycee_id LIMIT 1");
+        $stmt->execute(['lycee_id' => $lycee_id]);
+        return $stmt->fetch(PDO::FETCH_ASSOC);
+    }
+
+    public static function save($data) {
+        $existing = self::getByLyceeId($data['lycee_id']);
+
+        $sql = $existing
+            ? "UPDATE parametres_generaux SET nom_lycee = :nom_lycee, type_lycee = :type_lycee, annee_academique = :annee_academique, nombre_devoirs_par_trimestre = :nombre_devoirs_par_trimestre, modalite_paiement = :modalite_paiement, multilingue_actif = :multilingue_actif, biometrie_actif = :biometrie_actif, confidentialite_nationale = :confidentialite_nationale WHERE lycee_id = :lycee_id"
+            : "INSERT INTO parametres_generaux (lycee_id, nom_lycee, type_lycee, annee_academique, nombre_devoirs_par_trimestre, modalite_paiement, multilingue_actif, biometrie_actif, confidentialite_nationale) VALUES (:lycee_id, :nom_lycee, :type_lycee, :annee_academique, :nombre_devoirs_par_trimestre, :modalite_paiement, :multilingue_actif, :biometrie_actif, :confidentialite_nationale)";
+
+        $db = Database::getInstance();
+        $stmt = $db->prepare($sql);
+
+        return $stmt->execute([
+            'lycee_id' => $data['lycee_id'],
+            'nom_lycee' => $data['nom_lycee'],
+            'type_lycee' => $data['type_lycee'],
+            'annee_academique' => $data['annee_academique'],
+            'nombre_devoirs_par_trimestre' => $data['nombre_devoirs_par_trimestre'] ?? 2,
+            'modalite_paiement' => $data['modalite_paiement'],
+            'multilingue_actif' => isset($data['multilingue_actif']) ? 1 : 0,
+            'biometrie_actif' => isset($data['biometrie_actif']) ? 1 : 0,
+            'confidentialite_nationale' => isset($data['confidentialite_nationale']) ? 1 : 0,
+        ]);
+    }
+}
+?>

--- a/src/models/User.php
+++ b/src/models/User.php
@@ -151,6 +151,18 @@ class User {
 
     // --- Teacher-specific methods ---
 
+    public static function findOneByRoleName($role_name) {
+        $db = Database::getInstance();
+        $stmt = $db->prepare("
+            SELECT u.* FROM utilisateurs u
+            JOIN roles r ON u.role_id = r.id_role
+            WHERE r.nom_role = :role_name
+            LIMIT 1
+        ");
+        $stmt->execute(['role_name' => $role_name]);
+        return $stmt->fetch(PDO::FETCH_ASSOC);
+    }
+
     public static function getTeacherAssignments($teacher_id) {
         $db = Database::getInstance();
         $stmt = $db->prepare("

--- a/src/views/setup/step0_choice.php
+++ b/src/views/setup/step0_choice.php
@@ -1,0 +1,32 @@
+<?php require_once __DIR__ . '/../layouts/header.php'; ?>
+
+<div class="max-w-2xl mx-auto mt-10">
+    <div class="bg-white p-8 rounded-lg shadow-lg text-center">
+        <h1 class="text-3xl font-bold mb-4"><?= _('Welcome to Application Setup') ?></h1>
+        <p class="text-gray-600 mb-8"><?= _('Please choose the installation mode for your application.') ?></p>
+
+        <form action="/setup/choice" method="POST">
+            <div class="space-y-4">
+                <label class="block p-4 border rounded-lg hover:bg-gray-100 cursor-pointer">
+                    <input type="radio" name="install_mode" value="single" class="mr-2" checked>
+                    <strong class="text-lg"><?= _('Single School Installation') ?></strong>
+                    <p class="text-sm text-gray-500"><?= _('For a private or semi-public school managing only its own data.') ?></p>
+                </label>
+
+                <label class="block p-4 border rounded-lg hover:bg-gray-100 cursor-pointer">
+                    <input type="radio" name="install_mode" value="multi" class="mr-2">
+                    <strong class="text-lg"><?= _('Multi-School Installation') ?></strong>
+                    <p class="text-sm text-gray-500"><?= _('For national or regional administration managing multiple schools.') ?></p>
+                </label>
+            </div>
+
+            <div class="mt-8">
+                <button type="submit" class="w-full bg-blue-500 hover:bg-blue-700 text-white font-bold py-3 px-4 rounded">
+                    <?= _('Continue') ?> &rarr;
+                </button>
+            </div>
+        </form>
+    </div>
+</div>
+
+<?php require_once __DIR__ . '/../layouts/footer.php'; ?>

--- a/src/views/setup/step1_multi.php
+++ b/src/views/setup/step1_multi.php
@@ -1,0 +1,42 @@
+<?php require_once __DIR__ . '/../layouts/header.php'; ?>
+
+<div class="max-w-2xl mx-auto mt-10">
+    <div class="bg-white p-8 rounded-lg shadow-lg">
+        <h1 class="text-3xl font-bold mb-6"><?= _('Setup: Multi-School') ?></h1>
+
+        <form action="/setup/finish" method="POST">
+            <input type="hidden" name="install_mode" value="multi">
+
+            <fieldset class="border p-4 rounded-md">
+                <legend class="text-xl font-semibold px-2"><?= _('National Administrator Account') ?></legend>
+                <p class="text-sm text-gray-600 mb-4"><?= _('This account will have the rights to create and manage all high schools.') ?></p>
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
+                    <div>
+                        <label for="prenom" class="block text-sm font-bold mb-2"><?= _('First Name') ?></label>
+                        <input type="text" name="prenom" id="prenom" class="shadow border rounded w-full py-2 px-3" required>
+                    </div>
+                    <div>
+                        <label for="nom" class="block text-sm font-bold mb-2"><?= _('Last Name') ?></label>
+                        <input type="text" name="nom" id="nom" class="shadow border rounded w-full py-2 px-3" required>
+                    </div>
+                    <div class="md:col-span-2">
+                        <label for="email" class="block text-sm font-bold mb-2"><?= _('Email') ?></label>
+                        <input type="email" name="email" id="email" class="shadow border rounded w-full py-2 px-3" required>
+                    </div>
+                    <div class="md:col-span-2">
+                        <label for="mot_de_passe" class="block text-sm font-bold mb-2"><?= _('Password') ?></label>
+                        <input type="password" name="mot_de_passe" id="mot_de_passe" class="shadow border rounded w-full py-2 px-3" required>
+                    </div>
+                </div>
+            </fieldset>
+
+            <div class="mt-8">
+                <button type="submit" class="w-full bg-blue-500 hover:bg-blue-700 text-white font-bold py-3 px-4 rounded">
+                    <?= _('Complete Setup') ?>
+                </button>
+            </div>
+        </form>
+    </div>
+</div>
+
+<?php require_once __DIR__ . '/../layouts/footer.php'; ?>

--- a/src/views/setup/step1_single.php
+++ b/src/views/setup/step1_single.php
@@ -1,0 +1,65 @@
+<?php require_once __DIR__ . '/../layouts/header.php'; ?>
+
+<div class="max-w-3xl mx-auto mt-10">
+    <div class="bg-white p-8 rounded-lg shadow-lg">
+        <h1 class="text-3xl font-bold mb-6"><?= _('Setup: Single School') ?></h1>
+
+        <form action="/setup/finish" method="POST">
+            <input type="hidden" name="install_mode" value="single">
+
+            <!-- School Details -->
+            <fieldset class="border p-4 rounded-md mb-6">
+                <legend class="text-xl font-semibold px-2"><?= _('School Information') ?></legend>
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
+                    <div>
+                        <label for="nom_lycee" class="block text-sm font-bold mb-2"><?= _('High School Name') ?></label>
+                        <input type="text" name="nom_lycee" id="nom_lycee" class="shadow border rounded w-full py-2 px-3" required>
+                    </div>
+                    <div>
+                        <label for="type_lycee" class="block text-sm font-bold mb-2"><?= _('High School Type') ?></label>
+                        <select name="type_lycee" id="type_lycee" class="shadow border rounded w-full py-2 px-3" required>
+                            <option value="prive"><?= _('Private') ?></option>
+                            <option value="parapublic"><?= _('Parapublic') ?></option>
+                            <option value="public"><?= _('Public') ?></option>
+                        </select>
+                    </div>
+                     <div class="md:col-span-2">
+                        <label for="annee_academique" class="block text-sm font-bold mb-2"><?= _('Current Academic Year') ?></label>
+                        <input type="text" name="annee_academique" id="annee_academique" class="shadow border rounded w-full py-2 px-3" placeholder="Ex: 2024-2025" required>
+                    </div>
+                </div>
+            </fieldset>
+
+            <!-- Admin Account -->
+            <fieldset class="border p-4 rounded-md">
+                <legend class="text-xl font-semibold px-2"><?= _('Local Administrator Account') ?></legend>
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
+                    <div>
+                        <label for="admin_prenom" class="block text-sm font-bold mb-2"><?= _('First Name') ?></label>
+                        <input type="text" name="admin_prenom" id="admin_prenom" class="shadow border rounded w-full py-2 px-3" required>
+                    </div>
+                    <div>
+                        <label for="admin_nom" class="block text-sm font-bold mb-2"><?= _('Last Name') ?></label>
+                        <input type="text" name="admin_nom" id="admin_nom" class="shadow border rounded w-full py-2 px-3" required>
+                    </div>
+                    <div class="md:col-span-2">
+                        <label for="admin_email" class="block text-sm font-bold mb-2"><?= _('Email') ?></label>
+                        <input type="email" name="admin_email" id="admin_email" class="shadow border rounded w-full py-2 px-3" required>
+                    </div>
+                    <div class="md:col-span-2">
+                        <label for="admin_pass" class="block text-sm font-bold mb-2"><?= _('Password') ?></label>
+                        <input type="password" name="admin_pass" id="admin_pass" class="shadow border rounded w-full py-2 px-3" required>
+                    </div>
+                </div>
+            </fieldset>
+
+            <div class="mt-8">
+                <button type="submit" class="w-full bg-blue-500 hover:bg-blue-700 text-white font-bold py-3 px-4 rounded">
+                    <?= _('Complete Setup') ?>
+                </button>
+            </div>
+        </form>
+    </div>
+</div>
+
+<?php require_once __DIR__ . '/../layouts/footer.php'; ?>


### PR DESCRIPTION
This commit introduces a setup wizard for the application's first launch. This provides a user-friendly way to perform the initial configuration without manual database setup.

Key features implemented:
- A detection logic in `public/index.php` that checks if setup is needed and redirects to the wizard.
- A multi-step setup process managed by a new `SetupController`.
- The wizard first prompts the user to choose between a "Single-School" or "Multi-School" installation mode.
- If "Single-School" is chosen, the wizard guides the user to create the school, its parameters, and a local administrator account.
- If "Multi-School" is chosen, the wizard guides the user to create the `super_admin_national` account.
- The database interaction is handled in a transaction to ensure data integrity.