### PR TITLE
feat: Overhaul personnel management module and fix setup bug

### DIFF
--- a/src/controllers/SetupController.php
+++ b/src/controllers/SetupController.php
@@ -61,13 +61,16 @@ class SetupController {
         try {
             $db->beginTransaction();
 
-            // 1. Create the Lycee
+            // 1. Create the Lycee and get its ID
             $lycee_data = [
                 'nom_lycee' => $data['nom_lycee'],
                 'type_lycee' => $data['type_lycee'],
             ];
-            Lycee::save($lycee_data);
-            $lycee_id = $db->lastInsertId();
+            $lycee_id = Lycee::save($lycee_data);
+
+            if (!$lycee_id) {
+                throw new Exception("Failed to create the lycee.");
+            }
 
             // 2. Create a specific admin role for this Lycee
             $role_data = [

--- a/src/models/CahierTexte.php
+++ b/src/models/CahierTexte.php
@@ -4,42 +4,74 @@ require_once __DIR__ . '/../config/database.php';
 
 class CahierTexte {
 
-    public static function findByTeacher($professeur_id, $lycee_id) {
+    public static function findAllByPersonnel($personnel_id, $ecole_id) {
         $db = Database::getInstance();
         $stmt = $db->prepare("
             SELECT ct.*, c.nom_classe, m.nom_matiere
             FROM cahier_texte ct
             JOIN classes c ON ct.classe_id = c.id_classe
             JOIN matieres m ON ct.matiere_id = m.id_matiere
-            WHERE ct.professeur_id = :professeur_id AND ct.lycee_id = :lycee_id
+            WHERE ct.personnel_id = :personnel_id AND ct.ecole_id = :ecole_id
             ORDER BY ct.date_cours DESC
         ");
-        $stmt->execute(['professeur_id' => $professeur_id, 'lycee_id' => $lycee_id]);
+        $stmt->execute(['personnel_id' => $personnel_id, 'ecole_id' => $ecole_id]);
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }
 
-    public static function create($data) {
+    public static function findById($id) {
         $db = Database::getInstance();
-        $sql = "INSERT INTO cahier_texte (professeur_id, classe_id, matiere_id, date_cours, heure_debut, heure_fin, contenu_cours, exercices, lycee_id)
-                VALUES (:professeur_id, :classe_id, :matiere_id, :date_cours, :heure_debut, :heure_fin, :contenu_cours, :exercices, :lycee_id)";
+        $stmt = $db->prepare("SELECT * FROM cahier_texte WHERE cahier_id = :id");
+        $stmt->execute(['id' => $id]);
+        return $stmt->fetch(PDO::FETCH_ASSOC);
+    }
+
+    public static function save($data) {
+        $isUpdate = !empty($data['cahier_id']);
+        $db = Database::getInstance();
+
+        if ($isUpdate) {
+            $sql = "UPDATE cahier_texte SET
+                        personnel_id = :personnel_id, classe_id = :classe_id, matiere_id = :matiere_id,
+                        date_cours = :date_cours, heure_debut = :heure_debut, heure_fin = :heure_fin,
+                        contenu_cours = :contenu_cours, travail_donne = :travail_donne,
+                        observation = :observation, annee_id = :annee_id, ecole_id = :ecole_id
+                    WHERE cahier_id = :cahier_id";
+        } else {
+            $sql = "INSERT INTO cahier_texte (
+                        personnel_id, classe_id, matiere_id, date_cours, heure_debut, heure_fin,
+                        contenu_cours, travail_donne, observation, annee_id, ecole_id
+                    ) VALUES (
+                        :personnel_id, :classe_id, :matiere_id, :date_cours, :heure_debut, :heure_fin,
+                        :contenu_cours, :travail_donne, :observation, :annee_id, :ecole_id
+                    )";
+        }
 
         $stmt = $db->prepare($sql);
-        return $stmt->execute([
-            'professeur_id' => $data['professeur_id'],
+
+        $params = [
+            'personnel_id' => $data['personnel_id'],
             'classe_id' => $data['classe_id'],
             'matiere_id' => $data['matiere_id'],
             'date_cours' => $data['date_cours'],
             'heure_debut' => $data['heure_debut'] ?: null,
             'heure_fin' => $data['heure_fin'] ?: null,
-            'contenu_cours' => $data['contenu_cours'] ?: null,
-            'exercices' => $data['exercices'] ?: null,
-            'lycee_id' => $data['lycee_id'],
-        ]);
+            'contenu_cours' => $data['contenu_cours'] ?? null,
+            'travail_donne' => $data['travail_donne'] ?? null,
+            'observation' => $data['observation'] ?? null,
+            'annee_id' => $data['annee_id'] ?? null,
+            'ecole_id' => $data['ecole_id'],
+        ];
+
+        if ($isUpdate) {
+            $params['cahier_id'] = $data['cahier_id'];
+        }
+
+        return $stmt->execute($params);
     }
 
     public static function delete($id) {
         $db = Database::getInstance();
-        $stmt = $db->prepare("DELETE FROM cahier_texte WHERE id_cahier = :id");
+        $stmt = $db->prepare("DELETE FROM cahier_texte WHERE cahier_id = :id");
         return $stmt->execute(['id' => $id]);
     }
 }

--- a/src/models/Lycee.php
+++ b/src/models/Lycee.php
@@ -39,17 +39,17 @@ class Lycee {
     /**
      * Save a lycee (create or update).
      * @param array $data The lycee data.
-     * @return bool True on success, false on failure.
+     * @return int|false The ID of the saved lycee on success, false on failure.
      */
     public static function save($data) {
         $isUpdate = !empty($data['id_lycee']);
+        $db = Database::getInstance();
 
         $sql = $isUpdate
             ? "UPDATE lycees SET nom_lycee = :nom_lycee, type_lycee = :type_lycee, adresse = :adresse, ville = :ville, quartier = :quartier, telephone = :telephone, email = :email WHERE id_lycee = :id_lycee"
             : "INSERT INTO lycees (nom_lycee, type_lycee, adresse, ville, quartier, telephone, email) VALUES (:nom_lycee, :type_lycee, :adresse, :ville, :quartier, :telephone, :email)";
 
         try {
-            $db = Database::getInstance();
             $stmt = $db->prepare($sql);
 
             $params = [
@@ -66,7 +66,17 @@ class Lycee {
                 $params['id_lycee'] = $data['id_lycee'];
             }
 
-            return $stmt->execute($params);
+            $success = $stmt->execute($params);
+
+            if (!$success) {
+                return false;
+            }
+
+            if ($isUpdate) {
+                return $data['id_lycee'];
+            } else {
+                return $db->lastInsertId();
+            }
         } catch (PDOException $e) {
             error_log("Error in Lycee::save: " . $e->getMessage());
             return false;

--- a/src/models/TypeContrat.php
+++ b/src/models/TypeContrat.php
@@ -33,8 +33,8 @@ class TypeContrat {
         $isUpdate = !empty($data['id_contrat']);
 
         $sql = $isUpdate
-            ? "UPDATE type_contrat SET libelle = :libelle, description = :description, lycee_id = :lycee_id WHERE id_contrat = :id_contrat"
-            : "INSERT INTO type_contrat (libelle, description, lycee_id) VALUES (:libelle, :description, :lycee_id)";
+            ? "UPDATE type_contrat SET libelle = :libelle, description = :description, type_paiement = :type_paiement, prise_en_charge = :prise_en_charge, lycee_id = :lycee_id WHERE id_contrat = :id_contrat"
+            : "INSERT INTO type_contrat (libelle, description, type_paiement, prise_en_charge, lycee_id) VALUES (:libelle, :description, :type_paiement, :prise_en_charge, :lycee_id)";
 
         $db = Database::getInstance();
         $stmt = $db->prepare($sql);
@@ -42,6 +42,8 @@ class TypeContrat {
         $params = [
             'libelle' => $data['libelle'],
             'description' => $data['description'] ?: null,
+            'type_paiement' => $data['type_paiement'] ?? 'fixe',
+            'prise_en_charge' => $data['prise_en_charge'] ?? 'Ecole',
             'lycee_id' => $data['lycee_id'] ?: null,
         ];
 

--- a/src/models/User.php
+++ b/src/models/User.php
@@ -6,22 +6,40 @@ class User {
     public $id_user;
     public $nom;
     public $prenom;
+    public $sexe;
+    public $date_naissance;
+    public $lieu_naissance;
+    public $adresse;
+    public $telephone;
     public $email;
     public $mot_de_passe;
-    public $role;
+    public $fonction;
+    public $role_id;
     public $lycee_id;
+    public $contrat_id;
+    public $date_embauche;
     public $actif;
+    public $photo;
 
     public function __construct($data = []) {
         if (!empty($data)) {
             $this->id_user = $data['id_user'] ?? null;
             $this->nom = $data['nom'] ?? '';
             $this->prenom = $data['prenom'] ?? '';
+            $this->sexe = $data['sexe'] ?? null;
+            $this->date_naissance = $data['date_naissance'] ?? null;
+            $this->lieu_naissance = $data['lieu_naissance'] ?? null;
+            $this->adresse = $data['adresse'] ?? null;
+            $this->telephone = $data['telephone'] ?? null;
             $this->email = $data['email'] ?? '';
             $this->mot_de_passe = $data['mot_de_passe'] ?? '';
+            $this->fonction = $data['fonction'] ?? null;
             $this->role_id = $data['role_id'] ?? null;
             $this->lycee_id = $data['lycee_id'] ?? null;
+            $this->contrat_id = $data['contrat_id'] ?? null;
+            $this->date_embauche = $data['date_embauche'] ?? null;
             $this->actif = $data['actif'] ?? true;
+            $this->photo = $data['photo'] ?? null;
         }
     }
 
@@ -102,15 +120,23 @@ class User {
         $isUpdate = !empty($data['id_user']);
 
         if ($isUpdate) {
-            $sql = "UPDATE utilisateurs SET nom = :nom, prenom = :prenom, email = :email, role_id = :role_id, actif = :actif, lycee_id = :lycee_id";
-            // Only update password if a new one is provided
+            $sql = "UPDATE utilisateurs SET
+                        nom = :nom, prenom = :prenom, sexe = :sexe, date_naissance = :date_naissance,
+                        lieu_naissance = :lieu_naissance, adresse = :adresse, telephone = :telephone,
+                        email = :email, fonction = :fonction, role_id = :role_id, lycee_id = :lycee_id,
+                        contrat_id = :contrat_id, date_embauche = :date_embauche, actif = :actif, photo = :photo";
             if (!empty($data['mot_de_passe'])) {
                 $sql .= ", mot_de_passe = :mot_de_passe";
             }
             $sql .= " WHERE id_user = :id_user";
         } else {
-            $sql = "INSERT INTO utilisateurs (nom, prenom, email, mot_de_passe, role_id, actif, lycee_id)
-                    VALUES (:nom, :prenom, :email, :mot_de_passe, :role_id, :actif, :lycee_id)";
+            $sql = "INSERT INTO utilisateurs (
+                        nom, prenom, sexe, date_naissance, lieu_naissance, adresse, telephone, email,
+                        mot_de_passe, fonction, role_id, lycee_id, contrat_id, date_embauche, actif, photo
+                    ) VALUES (
+                        :nom, :prenom, :sexe, :date_naissance, :lieu_naissance, :adresse, :telephone, :email,
+                        :mot_de_passe, :fonction, :role_id, :lycee_id, :contrat_id, :date_embauche, :actif, :photo
+                    )";
         }
 
         $db = Database::getInstance();
@@ -119,21 +145,32 @@ class User {
         $params = [
             'nom' => $data['nom'],
             'prenom' => $data['prenom'],
+            'sexe' => $data['sexe'] ?? null,
+            'date_naissance' => $data['date_naissance'] ?: null,
+            'lieu_naissance' => $data['lieu_naissance'] ?? null,
+            'adresse' => $data['adresse'] ?? null,
+            'telephone' => $data['telephone'] ?? null,
             'email' => $data['email'],
+            'fonction' => $data['fonction'] ?? null,
             'role_id' => $data['role_id'],
-            'actif' => $data['actif'] ?? 0,
             'lycee_id' => $data['lycee_id'] ?: null,
+            'contrat_id' => $data['contrat_id'] ?: null,
+            'date_embauche' => $data['date_embauche'] ?: null,
+            'actif' => $data['actif'] ?? 0,
+            'photo' => $data['photo'] ?? null,
         ];
 
         if (!empty($data['mot_de_passe'])) {
             $params['mot_de_passe'] = password_hash($data['mot_de_passe'], PASSWORD_DEFAULT);
+        } elseif (!$isUpdate) {
+            // Password is required for new users
+            if (empty($data['mot_de_passe'])) return false;
+            $params['mot_de_passe'] = password_hash($data['mot_de_passe'], PASSWORD_DEFAULT);
         }
+
 
         if ($isUpdate) {
             $params['id_user'] = $data['id_user'];
-        } else {
-            // Password is required for new users
-            if (empty($data['mot_de_passe'])) return false;
         }
 
         return $stmt->execute($params);


### PR DESCRIPTION
This commit implements a comprehensive overhaul of the personnel management module to align with the provided plan and fixes a critical bug that prevented initial application setup.

Key changes include:

1.  **Fix Initial Setup Bug:**
    - Modified `Lycee::save()` to return the new school's ID upon creation.
    - Updated `SetupController` to use the returned ID, resolving the foreign key constraint violation that caused the setup to fail.

2.  **Align Database with Plan:**
    - **Personnel Table:** The `utilisateurs` table has been expanded with all required personnel fields (sexe, dateNaissance, adresse, etc.), effectively turning it into the specified `personnel` table.
    - **Contract Table:** The `type_contrat` table now includes `type_paiement` and `prise_en_charge` to support different salary models (public, private, mixed).
    - **Salary Table:** The `salaires` table has been updated with detailed fields for payment tracking (`mode_paiement`, `nb_heures_travaillees`, `etat_paiement`).
    - **Timetable Table:** The missing `horaire_enseignant` table has been created.
    - **Digital Logbook:** The `cahier_texte` table has been updated to match the plan's specifications.

3.  **Update PHP Models:**
    - The corresponding PHP models (`User.php`, `TypeContrat.php`, `Salaire.php`, `CahierTexte.php`) have been updated to reflect all database schema changes, ensuring that the application logic can now leverage the new structure.