### PR TITLE
fix: Resolve critical nested transaction error in setup

### DIFF
--- a/src/models/Role.php
+++ b/src/models/Role.php
@@ -76,27 +76,19 @@ class Role {
     public static function setPermissions($role_id, $permission_ids) {
         $db = Database::getInstance();
 
-        try {
-            $db->beginTransaction();
+        // This method must be called within a transaction managed by the caller.
+        // It will throw a PDOException on failure, which should be caught by the caller.
 
-            // First, remove all existing permissions for this role
-            $stmt_delete = $db->prepare("DELETE FROM role_permissions WHERE role_id = :role_id");
-            $stmt_delete->execute(['role_id' => $role_id]);
+        // First, remove all existing permissions for this role
+        $stmt_delete = $db->prepare("DELETE FROM role_permissions WHERE role_id = :role_id");
+        $stmt_delete->execute(['role_id' => $role_id]);
 
-            // Now, add the new permissions
-            if (!empty($permission_ids)) {
-                $stmt_insert = $db->prepare("INSERT INTO role_permissions (role_id, permission_id) VALUES (:role_id, :permission_id)");
-                foreach ($permission_ids as $permission_id) {
-                    $stmt_insert->execute(['role_id' => $role_id, 'permission_id' => $permission_id]);
-                }
+        // Now, add the new permissions
+        if (!empty($permission_ids)) {
+            $stmt_insert = $db->prepare("INSERT INTO role_permissions (role_id, permission_id) VALUES (:role_id, :permission_id)");
+            foreach ($permission_ids as $permission_id) {
+                $stmt_insert->execute(['role_id' => $role_id, 'permission_id' => $permission_id]);
             }
-
-            $db->commit();
-            return true;
-        } catch (PDOException $e) {
-            $db->rollBack();
-            error_log("Error in Role::setPermissions: " . $e->getMessage());
-            return false;
         }
     }
 }


### PR DESCRIPTION
This commit fixes a critical bug that caused the initial application setup to fail with a 'there is no active transaction' error.

The root cause was a nested transaction within the `Role::setPermissions` method. The main `SetupController` initiates a global transaction, but the `setPermissions` method was incorrectly starting and committing its own transaction, prematurely closing the main one. This left subsequent database operations in the setup process to run outside of any transaction, leading to the final error.

The fix removes the transaction management (`beginTransaction`, `commit`, `rollBack`) from the `Role::setPermissions` method, ensuring it operates within the context of the calling transaction. This guarantees the atomicity of the entire setup process and resolves the bug.