### PR TITLE
Fix Parameter Saving and Schema Inconsistencies

### DIFF
--- a/src/controllers/SettingsController.php
+++ b/src/controllers/SettingsController.php
@@ -21,9 +21,21 @@ class SettingsController {
             $data = Validator::sanitize($_POST);
             $data['lycee_id'] = $lycee_id;
 
-            // In the old controller, this was ParamGeneral::update.
-            // Let's assume a general save/update method is better.
+            // Save general settings
             ParamGeneral::save($data);
+
+            // Save school identity settings if present in data
+            if (isset($data['nom_lycee']) || isset($data['type_lycee'])) {
+                $lycee_data = ParamLycee::findByLyceeId($lycee_id);
+                if ($lycee_data) {
+                    $update_data = array_merge($lycee_data, $data);
+                    // Logo is handled specially in ParamLycee::update,
+                    // but here we don't have file upload in the settings form,
+                    // so we make sure current_logo is set to avoid it being lost
+                    $update_data['current_logo'] = $lycee_data['logo'];
+                    ParamLycee::update($update_data);
+                }
+            }
 
             // Also handle active year change
             if(isset($data['annee_academique_id'])) {
@@ -35,7 +47,9 @@ class SettingsController {
             exit();
         }
 
-        $settings = ParamGeneral::findByLyceeId($lycee_id);
+        $gen_settings = ParamGeneral::findByLyceeId($lycee_id) ?: [];
+        $lycee_settings = ParamLycee::findByLyceeId($lycee_id) ?: [];
+        $settings = array_merge($gen_settings, $lycee_settings);
         $annees_academiques = AnneeAcademique::findAll();
 
         $data = [

--- a/src/models/Bulletin.php
+++ b/src/models/Bulletin.php
@@ -98,11 +98,11 @@ class Bulletin {
 
             // Fetch student and sequence info for the report card header
             $stmt_eleve = $db->prepare("
-                SELECT e.*, c.nom_classe, l.nom_lycee, aa.libelle as annee_academique
+                SELECT e.*, l.nom_lycee, aa.libelle as annee_academique
                 FROM eleves e
                 JOIN etudes et ON e.id_eleve = et.eleve_id
                 JOIN classes c ON et.classe_id = c.id_classe
-                JOIN lycees l ON c.lycee_id = l.id_lycee
+                JOIN param_lycee l ON c.lycee_id = l.id
                 JOIN annees_academiques aa ON et.annee_academique_id = aa.id
                 WHERE e.id_eleve = :id AND et.actif = 1
             ");

--- a/src/models/Licence.php
+++ b/src/models/Licence.php
@@ -9,7 +9,7 @@ class Licence {
         $stmt = $db->query("
             SELECT l.*, ly.nom_lycee
             FROM licences l
-            JOIN lycees ly ON l.lycee_id = ly.id_lycee
+            JOIN param_lycee ly ON l.lycee_id = ly.id
             ORDER BY l.date_fin DESC
         ");
         return $stmt->fetchAll(PDO::FETCH_ASSOC);

--- a/src/models/ParamComposition.php
+++ b/src/models/ParamComposition.php
@@ -30,7 +30,7 @@ class ParamComposition {
                 $stmt_create->execute([
                     'lycee_id' => $lycee_id,
                     'annee_id' => $activeYear['id'],
-                    'userId' => Auth::get('id_user')
+                    'userId' => Auth::getUserId()
                 ]);
                 // Fetch the newly created record
                 $stmt->execute(['lycee_id' => $lycee_id, 'annee_id' => $activeYear['id']]);

--- a/src/models/ParamDevoir.php
+++ b/src/models/ParamDevoir.php
@@ -30,7 +30,7 @@ class ParamDevoir {
                 $stmt_create->execute([
                     'lycee_id' => $lycee_id,
                     'annee_id' => $activeYear['id'],
-                    'userId' => Auth::get('id_user')
+                    'userId' => Auth::getUserId()
                 ]);
                 // Fetch the newly created record
                 $stmt->execute(['lycee_id' => $lycee_id, 'annee_id' => $activeYear['id']]);

--- a/src/models/ParamGeneral.php
+++ b/src/models/ParamGeneral.php
@@ -83,7 +83,8 @@ class ParamGeneral {
                     nb_langue = :nb_langue,
                     langue_1 = :langue_1,
                     langue_2 = :langue_2,
-                    sequence_annuelle = :sequence_annuelle
+                    sequence_annuelle = :sequence_annuelle,
+                    mode_cycle = :mode_cycle
                 WHERE lycee_id = :lycee_id";
 
         try {
@@ -97,6 +98,7 @@ class ParamGeneral {
                 'langue_1' => $data['langue_1'],
                 'langue_2' => $data['langue_2'] ?? null,
                 'sequence_annuelle' => $data['sequence_annuelle'],
+                'mode_cycle' => $data['mode_cycle'] ?? 'separe_ceg_lycee',
                 'lycee_id' => $lycee_id
             ]);
         } catch (PDOException $e) {
@@ -108,12 +110,12 @@ class ParamGeneral {
         $db = Database::getInstance();
 
         // Check if a record already exists for the lycee_id
-        $stmt_check = $db->prepare("SELECT id FROM param_general WHERE lycee_id = :lycee_id");
+        $stmt_check = $db->prepare("SELECT * FROM param_general WHERE lycee_id = :lycee_id");
         $stmt_check->execute(['lycee_id' => $data['lycee_id']]);
-        $exists = $stmt_check->fetchColumn();
+        $existing = $stmt_check->fetch(PDO::FETCH_ASSOC);
 
-        if ($exists) {
-            // Update
+        if ($existing) {
+            // Update only fields that are provided in $data, otherwise keep existing values
             $sql = "UPDATE param_general SET
                         devise_pays = :devise_pays,
                         monnaie = :monnaie,
@@ -121,17 +123,27 @@ class ParamGeneral {
                         nb_langue = :nb_langue,
                         langue_1 = :langue_1,
                         langue_2 = :langue_2,
-                        sequence_annuelle = :sequence_annuelle
+                        sequence_annuelle = :sequence_annuelle,
+                        mode_cycle = :mode_cycle
                     WHERE lycee_id = :lycee_id";
-        } else {
-            // Create
-            $sql = "INSERT INTO param_general (lycee_id, devise_pays, monnaie, modalite_paiement, nb_langue, langue_1, langue_2, sequence_annuelle)
-                    VALUES (:lycee_id, :devise_pays, :monnaie, :modalite_paiement, :nb_langue, :langue_1, :langue_2, :sequence_annuelle)";
-        }
 
-        try {
-            $stmt = $db->prepare($sql);
-            return $stmt->execute([
+            $params = [
+                'lycee_id' => $data['lycee_id'],
+                'devise_pays' => $data['devise_pays'] ?? $existing['devise_pays'],
+                'monnaie' => $data['monnaie'] ?? $existing['monnaie'],
+                'modalite_paiement' => $data['modalite_paiement'] ?? $existing['modalite_paiement'],
+                'nb_langue' => $data['nb_langue'] ?? $existing['nb_langue'],
+                'langue_1' => $data['langue_1'] ?? $existing['langue_1'],
+                'langue_2' => $data['langue_2'] ?? $existing['langue_2'],
+                'sequence_annuelle' => $data['sequence_annuelle'] ?? $existing['sequence_annuelle'],
+                'mode_cycle' => $data['mode_cycle'] ?? $existing['mode_cycle']
+            ];
+        } else {
+            // Create with defaults
+            $sql = "INSERT INTO param_general (lycee_id, devise_pays, monnaie, modalite_paiement, nb_langue, langue_1, langue_2, sequence_annuelle, mode_cycle)
+                    VALUES (:lycee_id, :devise_pays, :monnaie, :modalite_paiement, :nb_langue, :langue_1, :langue_2, :sequence_annuelle, :mode_cycle)";
+
+            $params = [
                 'lycee_id' => $data['lycee_id'],
                 'devise_pays' => $data['devise_pays'] ?? 'XAF',
                 'monnaie' => $data['monnaie'] ?? 'FCFA',
@@ -139,8 +151,14 @@ class ParamGeneral {
                 'nb_langue' => $data['nb_langue'] ?? 1,
                 'langue_1' => $data['langue_1'] ?? 'Francais',
                 'langue_2' => $data['langue_2'] ?? null,
-                'sequence_annuelle' => $data['sequence_annuelle'] ?? 'Trimestrielle'
-            ]);
+                'sequence_annuelle' => $data['sequence_annuelle'] ?? 'Trimestrielle',
+                'mode_cycle' => $data['mode_cycle'] ?? 'separe_ceg_lycee'
+            ];
+        }
+
+        try {
+            $stmt = $db->prepare($sql);
+            return $stmt->execute($params);
         } catch (PDOException $e) {
             error_log("Error in ParamGeneral::save: " . $e->getMessage());
             return false;

--- a/src/models/ParamLycee.php
+++ b/src/models/ParamLycee.php
@@ -16,8 +16,8 @@ class ParamLycee {
         }
         try {
             $db = Database::getInstance();
-            // Corrected to query by lycee_id
-            $stmt = $db->prepare("SELECT * FROM param_lycee WHERE lycee_id = :lycee_id");
+            // Corrected to query by id
+            $stmt = $db->prepare("SELECT * FROM param_lycee WHERE id = :lycee_id");
             $stmt->execute(['lycee_id' => $lycee_id]);
             return $stmt->fetch(PDO::FETCH_ASSOC);
         } catch (PDOException $e) {
@@ -80,7 +80,7 @@ class ParamLycee {
                     logo = :logo,
                     type_lycee = :type_lycee,
                     boutique = :boutique
-                WHERE lycee_id = :lycee_id";
+                WHERE id = :lycee_id";
 
         try {
             $db = Database::getInstance();

--- a/src/views/boutique/articles/create.php
+++ b/src/views/boutique/articles/create.php
@@ -27,7 +27,7 @@
                     <label for="lycee_id" class="block text-gray-700 text-sm font-bold mb-2"><?= _('High School') ?></label>
                     <select name="lycee_id" id="lycee_id" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700" required>
                         <?php foreach ($lycees as $lycee): ?>
-                            <option value="<?= $lycee['id_lycee'] ?>"><?= htmlspecialchars($lycee['nom_lycee']) ?></option>
+                            <option value="<?= $lycee['id'] ?>"><?= htmlspecialchars($lycee['nom_lycee']) ?></option>
                         <?php endforeach; ?>
                     </select>
                 </div>

--- a/src/views/boutique/articles/edit.php
+++ b/src/views/boutique/articles/edit.php
@@ -28,7 +28,7 @@
                     <label for="lycee_id" class="block text-gray-700 text-sm font-bold mb-2"><?= _('High School') ?></label>
                     <select name="lycee_id" id="lycee_id" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700" required>
                         <?php foreach ($lycees as $lycee): ?>
-                            <option value="<?= $lycee['id_lycee'] ?>" <?= $article['lycee_id'] == $lycee['id_lycee'] ? 'selected' : '' ?>><?= htmlspecialchars($lycee['nom_lycee']) ?></option>
+                            <option value="<?= $lycee['id'] ?>" <?= $article['lycee_id'] == $lycee['id'] ? 'selected' : '' ?>><?= htmlspecialchars($lycee['nom_lycee']) ?></option>
                         <?php endforeach; ?>
                     </select>
                 </div>

--- a/src/views/classes/create.php
+++ b/src/views/classes/create.php
@@ -73,7 +73,7 @@
                                     <select name="lycee_id" id="lycee_id" class="form-select" required>
                                         <option value=""><?= _('-- Choisir un lycée --') ?></option>
                                         <?php foreach ($lycees as $lycee): ?>
-                                            <option value="<?= $lycee['id_lycee'] ?>"><?= htmlspecialchars($lycee['nom_lycee']) ?></option>
+                                            <option value="<?= $lycee['id'] ?>"><?= htmlspecialchars($lycee['nom_lycee']) ?></option>
                                         <?php endforeach; ?>
                                     </select>
                                 </div>

--- a/src/views/classes/edit.php
+++ b/src/views/classes/edit.php
@@ -73,7 +73,7 @@
                                     <label for="lycee_id" class="form-label"><?= _('Lycée') ?></label>
                                     <select name="lycee_id" id="lycee_id" class="form-select" required>
                                         <?php foreach ($lycees as $lycee): ?>
-                                             <option value="<?= $lycee['id_lycee'] ?>" <?= $classe['lycee_id'] == $lycee['id_lycee'] ? 'selected' : '' ?>>
+                                             <option value="<?= $lycee['id'] ?>" <?= $classe['lycee_id'] == $lycee['id'] ? 'selected' : '' ?>>
                                                 <?= htmlspecialchars($lycee['nom_lycee']) ?>
                                             </option>
                                         <?php endforeach; ?>

--- a/src/views/layouts/header_able.php
+++ b/src/views/layouts/header_able.php
@@ -45,7 +45,7 @@ if ($active_lycee_id) {
 // If no lycee is active (e.g., super admin first login), default to the first available one
 if (!$active_lycee && !empty($available_lycees)) {
     $active_lycee = $available_lycees[0];
-    $active_lycee_id = $active_lycee['id_lycee'];
+    $active_lycee_id = $active_lycee['id'];
 }
 
 // Fetch params for the now-determined active lycee
@@ -123,7 +123,7 @@ $notification_count = count($unread_notifications);
                     </a>
                     <div class="dropdown-menu">
                         <?php foreach ($available_lycees as $lycee): ?>
-                            <a href="/settings/change-lycee?id=<?= $lycee['id_lycee'] ?>" class="dropdown-item"><?= htmlspecialchars($lycee['nom_lycee']) ?></a>
+                            <a href="/settings/change-lycee?id=<?= $lycee['id'] ?>" class="dropdown-item"><?= htmlspecialchars($lycee['nom_lycee']) ?></a>
                         <?php endforeach; ?>
                     </div>
                 </div>

--- a/src/views/licences/create.php
+++ b/src/views/licences/create.php
@@ -12,7 +12,7 @@
                     <select name="lycee_id" id="lycee_id" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700" required>
                         <option value=""><?= _('-- Choose a high school --') ?></option>
                         <?php foreach ($lycees as $lycee): ?>
-                            <option value="<?= $lycee['id_lycee'] ?>"><?= htmlspecialchars($lycee['nom_lycee']) ?></option>
+                            <option value="<?= $lycee['id'] ?>"><?= htmlspecialchars($lycee['nom_lycee']) ?></option>
                         <?php endforeach; ?>
                     </select>
                 </div>

--- a/src/views/licences/edit.php
+++ b/src/views/licences/edit.php
@@ -12,7 +12,7 @@
                     <label for="lycee_id" class="block text-gray-700 text-sm font-bold mb-2"><?= _('High School') ?></label>
                     <select name="lycee_id" id="lycee_id" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700" required>
                         <?php foreach ($lycees as $lycee): ?>
-                            <option value="<?= $lycee['id_lycee'] ?>" <?= $licence['lycee_id'] == $lycee['id_lycee'] ? 'selected' : '' ?>><?= htmlspecialchars($lycee['nom_lycee']) ?></option>
+                            <option value="<?= $lycee['id'] ?>" <?= $licence['lycee_id'] == $lycee['id'] ? 'selected' : '' ?>><?= htmlspecialchars($lycee['nom_lycee']) ?></option>
                         <?php endforeach; ?>
                     </select>
                 </div>

--- a/src/views/lycees/edit.php
+++ b/src/views/lycees/edit.php
@@ -5,7 +5,7 @@
 
     <div class="bg-white p-8 rounded-lg shadow-lg">
         <form action="/lycees/update" method="POST">
-            <input type="hidden" name="id_lycee" value="<?= htmlspecialchars($lycee['id_lycee']) ?>">
+            <input type="hidden" name="id" value="<?= htmlspecialchars($lycee['id']) ?>">
 
             <div class="grid grid-cols-1 gap-6">
 

--- a/src/views/lycees/index.php
+++ b/src/views/lycees/index.php
@@ -32,9 +32,9 @@
                             <td class="px-6 py-4 whitespace-nowrap"><?= htmlspecialchars($lycee['type_lycee']) ?></td>
                             <td class="px-6 py-4 whitespace-nowrap"><?= htmlspecialchars($lycee['ville']) ?></td>
                             <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
-                                <a href="/lycees/edit?id=<?= $lycee['id_lycee'] ?>" class="text-indigo-600 hover:text-indigo-900"><?= _('Edit') ?></a>
+                                <a href="/lycees/edit?id=<?= $lycee['id'] ?>" class="text-indigo-600 hover:text-indigo-900"><?= _('Edit') ?></a>
                                 <form action="/lycees/destroy" method="POST" class="inline-block ml-4" onsubmit="return confirm('<?= _('Are you sure you want to delete this high school?') ?>');">
-                                    <input type="hidden" name="id" value="<?= $lycee['id_lycee'] ?>">
+                                    <input type="hidden" name="id" value="<?= $lycee['id'] ?>">
                                     <button type="submit" class="text-red-600 hover:text-red-900"><?= _('Delete') ?></button>
                                 </form>
                             </td>

--- a/src/views/roles/create.php
+++ b/src/views/roles/create.php
@@ -36,7 +36,7 @@
                                     <select name="lycee_id" id="lycee_id" class="form-select">
                                         <option value=""><?= _('Rôle Global') ?></option>
                                         <?php foreach ($lycees as $lycee): ?>
-                                            <option value="<?= $lycee['id_lycee'] ?>"><?= _('Spécifique à') ?>: <?= htmlspecialchars($lycee['nom_lycee']) ?></option>
+                                            <option value="<?= $lycee['id'] ?>"><?= _('Spécifique à') ?>: <?= htmlspecialchars($lycee['nom_lycee']) ?></option>
                                         <?php endforeach; ?>
                                     </select>
                                     <div class="form-text"><?= _('Laissez sur "Global" pour les rôles généraux (ex: Enseignant), ou assignez à une école pour un rôle local (ex: Administrateur local).') ?></div>

--- a/src/views/roles/edit.php
+++ b/src/views/roles/edit.php
@@ -41,7 +41,7 @@
                                         <select name="lycee_id" id="lycee_id" class="form-select">
                                             <option value="" <?= !$role['lycee_id'] ? 'selected' : '' ?>><?= _('Rôle Global') ?></option>
                                             <?php foreach ($lycees as $lycee): ?>
-                                                <option value="<?= $lycee['id_lycee'] ?>" <?= $role['lycee_id'] == $lycee['id_lycee'] ? 'selected' : '' ?>><?= _('Spécifique à') ?>: <?= htmlspecialchars($lycee['nom_lycee'] ?? '') ?></option>
+                                                <option value="<?= $lycee['id'] ?>" <?= $role['lycee_id'] == $lycee['id'] ? 'selected' : '' ?>><?= _('Spécifique à') ?>: <?= htmlspecialchars($lycee['nom_lycee'] ?? '') ?></option>
                                             <?php endforeach; ?>
                                         </select>
                                     </div>

--- a/src/views/users/_form.php
+++ b/src/views/users/_form.php
@@ -104,7 +104,7 @@
             <select name="lycee_id" id="lycee_id" class="form-select">
                 <option value=""><?= _('-- Aucun --') ?></option>
                 <?php foreach ($lycees as $lycee): ?>
-                    <option value="<?= $lycee['id_lycee'] ?>" <?= (isset($user['lycee_id']) && $user['lycee_id'] == $lycee['id_lycee']) ? 'selected' : '' ?>>
+                    <option value="<?= $lycee['id'] ?>" <?= (isset($user['lycee_id']) && $user['lycee_id'] == $lycee['id']) ? 'selected' : '' ?>>
                         <?= htmlspecialchars($lycee['nom_lycee']) ?>
                     </option>
                 <?php endforeach; ?>


### PR DESCRIPTION
The user reported that general, school, homework, and exam parameters were not being saved correctly. 

Upon investigation, I found several issues:
1. Missing fields: 'mode_cycle' was missing from the ParamGeneral model's save/update logic.
2. Database schema mismatch: The 'param_lycee' table uses 'id' as its primary key, but the code was frequently using 'id_lycee', leading to failed queries.
3. Incorrect Auth calls: Some models were using 'Auth::get('id_user')' instead of 'Auth::getUserId()'.
4. Partial saving in SettingsController: The central settings page was only saving some parameters while ignoring others.

I have addressed these issues by:
- Correcting the field mappings in the models.
- Standardizing the primary key reference for schools to 'id' across the entire application (models and views).
- Updating the SettingsController to correctly load and persist both general and school-identity settings.
- Enhancing the 'ParamGeneral::save' method to intelligently merge new data with existing records to prevent accidental data loss.

---
*PR created automatically by Jules for task [11313110564466387027](https://jules.google.com/task/11313110564466387027) started by @hassane-dev*