### PR TITLE
Fix image saving and data preservation bug

### DIFF
--- a/src/controllers/EleveController.php
+++ b/src/controllers/EleveController.php
@@ -140,19 +140,44 @@ class EleveController {
         if (!Auth::can('edit', 'eleve')) { $this->forbidden(); }
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $data = Validator::sanitize($_POST);
+            $id = $data['id_eleve'] ?? null;
+
+            if (!$id) {
+                header('Location: /eleves');
+                exit();
+            }
+
+            $currentEleve = Eleve::findById($id);
+            if (!$currentEleve) {
+                header('Location: /eleves');
+                exit();
+            }
+
             if (isset($_FILES['photo']) && $_FILES['photo']['error'] == UPLOAD_ERR_OK) {
                 $photoPath = $this->handlePhotoUpload($_FILES['photo']);
                 if ($photoPath) {
+                    // Delete old photo if exists
+                    if (!empty($currentEleve['photo'])) {
+                        $oldPhotoPath = __DIR__ . '/../../public' . $currentEleve['photo'];
+                        if (file_exists($oldPhotoPath)) {
+                            unlink($oldPhotoPath);
+                        }
+                    }
                     $data['photo'] = $photoPath;
                 }
             }
 
             if (empty($data['lycee_id'])) {
-                $eleve = Eleve::findById($data['id_eleve']);
-                $data['lycee_id'] = $eleve['lycee_id'] ?? Auth::get('lycee_id');
+                $data['lycee_id'] = $currentEleve['lycee_id'] ?? Auth::get('lycee_id');
             }
 
-            Eleve::save($data);
+            try {
+                Eleve::save($data);
+                $_SESSION['success_message'] = "Les informations de l'élève ont été mises à jour.";
+            } catch (Exception $e) {
+                error_log("Student update failed: " . $e->getMessage());
+                $_SESSION['error_message'] = "Erreur lors de la mise à jour : " . $e->getMessage();
+            }
         }
         header('Location: /eleves');
         exit();

--- a/src/controllers/UserController.php
+++ b/src/controllers/UserController.php
@@ -90,9 +90,11 @@ class UserController {
 
             try {
                 User::save($data);
+                $_SESSION['success_message'] = "Le membre du personnel a été créé avec succès.";
                 header('Location: /users');
                 exit();
-            } catch (InvalidArgumentException $e) {
+            } catch (Exception $e) {
+                error_log("User creation failed: " . $e->getMessage());
                 // Redisplay the form with an error message and pre-filled data
                 $lycee_id = Auth::get('lycee_id');
                 $lycees = (Auth::can('view_all_lycees', 'lycee')) ? Lycee::findAll() : [];
@@ -102,6 +104,7 @@ class UserController {
                 $is_edit = false;
                 $error = $e->getMessage();
                 require_once __DIR__ . '/../views/users/create.php';
+                exit();
             }
         }
     }
@@ -191,18 +194,21 @@ class UserController {
 
             try {
                 User::save($data);
+                $_SESSION['success_message'] = "Le membre du personnel a été mis à jour avec succès.";
                 header('Location: /users');
                 exit();
-            } catch (InvalidArgumentException $e) {
+            } catch (Exception $e) {
+                error_log("User update failed: " . $e->getMessage());
                 // Redisplay the form with an error message and pre-filled data
                 $id = $data['id_user'];
                 $user = $data; // Use submitted data to refill form
                 $lycees = (Auth::can('view_all_lycees', 'lycee')) ? Lycee::findAll() : [];
-                $contrats = TypeContrat::findAll($user['lycee_id']);
-                $roles = Role::findAll($user['lycee_id']);
+                $contrats = TypeContrat::findAll($user['lycee_id'] ?? Auth::get('lycee_id'));
+                $roles = Role::findAll($user['lycee_id'] ?? Auth::get('lycee_id'));
                 $is_edit = true;
                 $error = $e->getMessage();
                 require_once __DIR__ . '/../views/users/edit.php';
+                exit();
             }
         }
     }

--- a/src/models/Eleve.php
+++ b/src/models/Eleve.php
@@ -76,28 +76,41 @@ class Eleve {
 
         $fields = ['lycee_id', 'nom', 'prenom', 'date_naissance', 'lieu_naissance', 'nationalite', 'sexe', 'quartier', 'tel_parent', 'nom_pere', 'nom_mere', 'profession_pere', 'profession_mere', 'email', 'telephone', 'statut'];
 
-        $params = [];
-        foreach ($fields as $field) {
-            $params[$field] = $data[$field] ?? null;
+        if ($isUpdate) {
+            $currentData = self::findById($data['id_eleve']);
+            if (!$currentData) {
+                throw new InvalidArgumentException("Élève non trouvé.");
+            }
         }
 
-        if (!$isUpdate) {
+        $params = [];
+        foreach ($fields as $field) {
+            if (isset($data[$field])) {
+                $params[$field] = $data[$field];
+            } elseif ($isUpdate) {
+                // Keep current value if not provided during update
+                $params[$field] = $currentData[$field];
+            } else {
+                $params[$field] = null;
+            }
+        }
+
+        if (!$isUpdate && empty($params['statut'])) {
             $params['statut'] = 'en_attente';
         }
 
         if (!empty($data['photo'])) {
             $fields[] = 'photo';
             $params['photo'] = $data['photo'];
+        } elseif ($isUpdate) {
+            // Keep current photo if not provided
+            $fields[] = 'photo';
+            $params['photo'] = $currentData['photo'];
         }
 
         if ($isUpdate) {
-            // If photo is not provided during update, don't overwrite the existing one
-            if (empty($data['photo'])) {
-                $fields = array_filter($fields, fn($f) => $f !== 'photo');
-            }
             $setClauses = array_map(fn($f) => "`$f` = :$f", $fields);
             $sql = "UPDATE eleves SET " . implode(', ', $setClauses) . " WHERE id_eleve = :id_eleve";
-            $params = array_intersect_key($params, array_flip($fields));
             $params['id_eleve'] = $data['id_eleve'];
         } else {
             $columns = implode(', ', array_map(fn($f) => "`$f`", $fields));

--- a/src/models/User.php
+++ b/src/models/User.php
@@ -146,14 +146,17 @@ class User {
         // --- End Validation ---
 
         if ($isUpdate) {
+            $currentData = self::findById($data['id_user']);
+            if (!$currentData) {
+                throw new InvalidArgumentException("Membre du personnel non trouvé.");
+            }
+
             $sql = "UPDATE utilisateurs SET
                         nom = :nom, prenom = :prenom, sexe = :sexe, date_naissance = :date_naissance,
                         lieu_naissance = :lieu_naissance, adresse = :adresse, telephone = :telephone,
                         email = :email, fonction = :fonction, role_id = :role_id, lycee_id = :lycee_id,
-                        contrat_id = :contrat_id, date_embauche = :date_embauche, actif = :actif";
-            if (!empty($data['photo'])) {
-                $sql .= ", photo = :photo";
-            }
+                        contrat_id = :contrat_id, date_embauche = :date_embauche, actif = :actif,
+                        photo = :photo";
             if (!empty($data['mot_de_passe'])) {
                 $sql .= ", mot_de_passe = :mot_de_passe";
             }
@@ -171,25 +174,42 @@ class User {
         $db = Database::getInstance();
         $stmt = $db->prepare($sql);
 
-        $params = [
-            'nom' => $data['nom'],
-            'prenom' => $data['prenom'],
-            'sexe' => $data['sexe'] ?? null,
-            'date_naissance' => empty($data['date_naissance']) ? null : $data['date_naissance'],
-            'lieu_naissance' => $data['lieu_naissance'] ?? null,
-            'adresse' => $data['adresse'] ?? null,
-            'telephone' => $data['telephone'] ?? null,
-            'email' => $data['email'],
-            'fonction' => $data['fonction'] ?? null,
-            'role_id' => $data['role_id'],
-            'lycee_id' => empty($data['lycee_id']) ? null : (int)$data['lycee_id'],
-            'contrat_id' => empty($data['contrat_id']) ? null : (int)$data['contrat_id'],
-            'date_embauche' => empty($data['date_embauche']) ? null : $data['date_embauche'],
-            'actif' => $data['actif'] ?? 1, // Default to active
-        ];
-
-        if (!empty($data['photo']) || !$isUpdate) {
-            $params['photo'] = $data['photo'] ?? null;
+        if ($isUpdate) {
+            $params = [
+                'nom' => $data['nom'] ?? $currentData['nom'],
+                'prenom' => $data['prenom'] ?? $currentData['prenom'],
+                'sexe' => $data['sexe'] ?? $currentData['sexe'],
+                'date_naissance' => !isset($data['date_naissance']) ? $currentData['date_naissance'] : (empty($data['date_naissance']) ? null : $data['date_naissance']),
+                'lieu_naissance' => $data['lieu_naissance'] ?? $currentData['lieu_naissance'],
+                'adresse' => $data['adresse'] ?? $currentData['adresse'],
+                'telephone' => $data['telephone'] ?? $currentData['telephone'],
+                'email' => $data['email'] ?? $currentData['email'],
+                'fonction' => $data['fonction'] ?? $currentData['fonction'],
+                'role_id' => $data['role_id'] ?? $currentData['role_id'],
+                'lycee_id' => !isset($data['lycee_id']) ? $currentData['lycee_id'] : (empty($data['lycee_id']) ? null : (int)$data['lycee_id']),
+                'contrat_id' => !isset($data['contrat_id']) ? $currentData['contrat_id'] : (empty($data['contrat_id']) ? null : (int)$data['contrat_id']),
+                'date_embauche' => !isset($data['date_embauche']) ? $currentData['date_embauche'] : (empty($data['date_embauche']) ? null : $data['date_embauche']),
+                'actif' => $data['actif'] ?? $currentData['actif'],
+                'photo' => $data['photo'] ?? $currentData['photo'],
+            ];
+        } else {
+            $params = [
+                'nom' => $data['nom'],
+                'prenom' => $data['prenom'],
+                'sexe' => $data['sexe'] ?? null,
+                'date_naissance' => empty($data['date_naissance']) ? null : $data['date_naissance'],
+                'lieu_naissance' => $data['lieu_naissance'] ?? null,
+                'adresse' => $data['adresse'] ?? null,
+                'telephone' => $data['telephone'] ?? null,
+                'email' => $data['email'],
+                'fonction' => $data['fonction'] ?? null,
+                'role_id' => $data['role_id'],
+                'lycee_id' => empty($data['lycee_id']) ? null : (int)$data['lycee_id'],
+                'contrat_id' => empty($data['contrat_id']) ? null : (int)$data['contrat_id'],
+                'date_embauche' => empty($data['date_embauche']) ? null : $data['date_embauche'],
+                'actif' => $data['actif'] ?? 1,
+                'photo' => $data['photo'] ?? null,
+            ];
         }
 
         if (!empty($data['mot_de_passe'])) {


### PR DESCRIPTION
The issue was caused by the models' `save()` methods not accounting for existing data during updates. When a form was submitted (e.g., without a new photo or without the password field), the models would simply use `null` for those missing fields, overwriting the existing values in the database. 

I implemented a data-merging strategy in both `User` and `Eleve` models where the current record is fetched first, and then merged with the submitted data. I also improved the controllers to handle photo uploads more reliably, including deleting old files when new ones are uploaded, and added consistent error logging and user feedback.

---
*PR created automatically by Jules for task [11296414738245181700](https://jules.google.com/task/11296414738245181700) started by @hassane-dev*