### PR TITLE
Fix school logo management and settings options

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -52,6 +52,9 @@ CREATE TABLE `param_general` (
     `langue_2` VARCHAR(50),
     `sequence_annuelle` ENUM('Semestrielle', 'Trimestrielle') NOT NULL DEFAULT 'Trimestrielle',
     `mode_cycle` ENUM('lycee_unique', 'separe_ceg_lycee') NOT NULL DEFAULT 'separe_ceg_lycee',
+    `multilingue_actif` BOOLEAN DEFAULT FALSE,
+    `biometrie_actif` BOOLEAN DEFAULT FALSE,
+    `confidentialite_nationale` BOOLEAN DEFAULT FALSE,
     `cree_le` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (`lycee_id`) REFERENCES `param_lycee`(`id`) ON DELETE CASCADE
 );

--- a/src/controllers/SettingsController.php
+++ b/src/controllers/SettingsController.php
@@ -2,6 +2,7 @@
 
 require_once __DIR__ . '/../models/AnneeAcademique.php';
 require_once __DIR__ . '/../models/ParamGeneral.php';
+require_once __DIR__ . '/../models/ParamLycee.php';
 require_once __DIR__ . '/../core/Validator.php';
 require_once __DIR__ . '/../core/View.php';
 
@@ -21,17 +22,19 @@ class SettingsController {
             $data = Validator::sanitize($_POST);
             $data['lycee_id'] = $lycee_id;
 
+            // Handle checkboxes/switches that are not sent in POST if unchecked
+            $data['multilingue_actif'] = isset($_POST['multilingue_actif']) ? 1 : 0;
+            $data['biometrie_actif'] = isset($_POST['biometrie_actif']) ? 1 : 0;
+            $data['confidentialite_nationale'] = isset($_POST['confidentialite_nationale']) ? 1 : 0;
+
             // Save general settings
             ParamGeneral::save($data);
 
             // Save school identity settings if present in data
-            if (isset($data['nom_lycee']) || isset($data['type_lycee'])) {
+            if (isset($data['nom_lycee']) || isset($data['type_lycee']) || isset($_FILES['logo'])) {
                 $lycee_data = ParamLycee::findByLyceeId($lycee_id);
                 if ($lycee_data) {
                     $update_data = array_merge($lycee_data, $data);
-                    // Logo is handled specially in ParamLycee::update,
-                    // but here we don't have file upload in the settings form,
-                    // so we make sure current_logo is set to avoid it being lost
                     $update_data['current_logo'] = $lycee_data['logo'];
                     ParamLycee::update($update_data);
                 }

--- a/src/models/ParamGeneral.php
+++ b/src/models/ParamGeneral.php
@@ -84,7 +84,10 @@ class ParamGeneral {
                     langue_1 = :langue_1,
                     langue_2 = :langue_2,
                     sequence_annuelle = :sequence_annuelle,
-                    mode_cycle = :mode_cycle
+                    mode_cycle = :mode_cycle,
+                    multilingue_actif = :multilingue_actif,
+                    biometrie_actif = :biometrie_actif,
+                    confidentialite_nationale = :confidentialite_nationale
                 WHERE lycee_id = :lycee_id";
 
         try {
@@ -99,6 +102,9 @@ class ParamGeneral {
                 'langue_2' => $data['langue_2'] ?? null,
                 'sequence_annuelle' => $data['sequence_annuelle'],
                 'mode_cycle' => $data['mode_cycle'] ?? 'separe_ceg_lycee',
+                'multilingue_actif' => $data['multilingue_actif'] ?? 0,
+                'biometrie_actif' => $data['biometrie_actif'] ?? 0,
+                'confidentialite_nationale' => $data['confidentialite_nationale'] ?? 0,
                 'lycee_id' => $lycee_id
             ]);
         } catch (PDOException $e) {
@@ -124,7 +130,10 @@ class ParamGeneral {
                         langue_1 = :langue_1,
                         langue_2 = :langue_2,
                         sequence_annuelle = :sequence_annuelle,
-                        mode_cycle = :mode_cycle
+                        mode_cycle = :mode_cycle,
+                        multilingue_actif = :multilingue_actif,
+                        biometrie_actif = :biometrie_actif,
+                        confidentialite_nationale = :confidentialite_nationale
                     WHERE lycee_id = :lycee_id";
 
             $params = [
@@ -136,12 +145,15 @@ class ParamGeneral {
                 'langue_1' => $data['langue_1'] ?? $existing['langue_1'],
                 'langue_2' => $data['langue_2'] ?? $existing['langue_2'],
                 'sequence_annuelle' => $data['sequence_annuelle'] ?? $existing['sequence_annuelle'],
-                'mode_cycle' => $data['mode_cycle'] ?? $existing['mode_cycle']
+                'mode_cycle' => $data['mode_cycle'] ?? $existing['mode_cycle'],
+                'multilingue_actif' => $data['multilingue_actif'] ?? $existing['multilingue_actif'],
+                'biometrie_actif' => $data['biometrie_actif'] ?? $existing['biometrie_actif'],
+                'confidentialite_nationale' => $data['confidentialite_nationale'] ?? $existing['confidentialite_nationale']
             ];
         } else {
             // Create with defaults
-            $sql = "INSERT INTO param_general (lycee_id, devise_pays, monnaie, modalite_paiement, nb_langue, langue_1, langue_2, sequence_annuelle, mode_cycle)
-                    VALUES (:lycee_id, :devise_pays, :monnaie, :modalite_paiement, :nb_langue, :langue_1, :langue_2, :sequence_annuelle, :mode_cycle)";
+            $sql = "INSERT INTO param_general (lycee_id, devise_pays, monnaie, modalite_paiement, nb_langue, langue_1, langue_2, sequence_annuelle, mode_cycle, multilingue_actif, biometrie_actif, confidentialite_nationale)
+                    VALUES (:lycee_id, :devise_pays, :monnaie, :modalite_paiement, :nb_langue, :langue_1, :langue_2, :sequence_annuelle, :mode_cycle, :multilingue_actif, :biometrie_actif, :confidentialite_nationale)";
 
             $params = [
                 'lycee_id' => $data['lycee_id'],
@@ -152,7 +164,10 @@ class ParamGeneral {
                 'langue_1' => $data['langue_1'] ?? 'Francais',
                 'langue_2' => $data['langue_2'] ?? null,
                 'sequence_annuelle' => $data['sequence_annuelle'] ?? 'Trimestrielle',
-                'mode_cycle' => $data['mode_cycle'] ?? 'separe_ceg_lycee'
+                'mode_cycle' => $data['mode_cycle'] ?? 'separe_ceg_lycee',
+                'multilingue_actif' => $data['multilingue_actif'] ?? 0,
+                'biometrie_actif' => $data['biometrie_actif'] ?? 0,
+                'confidentialite_nationale' => $data['confidentialite_nationale'] ?? 0
             ];
         }
 

--- a/src/views/lycees/create.php
+++ b/src/views/lycees/create.php
@@ -4,7 +4,7 @@
     <h2 class="text-2xl font-bold mb-6"><?= _('Add New High School') ?></h2>
 
     <div class="bg-white p-8 rounded-lg shadow-lg">
-        <form action="/lycees/store" method="POST">
+        <form action="/lycees/store" method="POST" enctype="multipart/form-data">
             <div class="grid grid-cols-1 gap-6">
 
                 <div>
@@ -13,11 +13,16 @@
                 </div>
 
                 <div>
+                    <label for="logo" class="block text-gray-700 text-sm font-bold mb-2"><?= _('Logo') ?></label>
+                    <input type="file" name="logo" id="logo" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700">
+                </div>
+
+                <div>
                     <label for="type_lycee" class="block text-gray-700 text-sm font-bold mb-2"><?= _('High School Type') ?></label>
                     <select name="type_lycee" id="type_lycee" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700" required>
                         <option value="public"><?= _('Public') ?></option>
                         <option value="prive"><?= _('Private') ?></option>
-                        <option value="parapublic"><?= _('Parapublic') ?></option>
+                        <option value="semi-public"><?= _('Semi-public') ?></option>
                     </select>
                 </div>
 

--- a/src/views/lycees/edit.php
+++ b/src/views/lycees/edit.php
@@ -4,8 +4,9 @@
     <h2 class="text-2xl font-bold mb-6"><?= _('Edit High School') ?></h2>
 
     <div class="bg-white p-8 rounded-lg shadow-lg">
-        <form action="/lycees/update" method="POST">
+        <form action="/lycees/update" method="POST" enctype="multipart/form-data">
             <input type="hidden" name="id" value="<?= htmlspecialchars($lycee['id']) ?>">
+            <input type="hidden" name="current_logo" value="<?= htmlspecialchars($lycee['logo']) ?>">
 
             <div class="grid grid-cols-1 gap-6">
 
@@ -15,11 +16,21 @@
                 </div>
 
                 <div>
+                    <label for="logo" class="block text-gray-700 text-sm font-bold mb-2"><?= _('Logo') ?></label>
+                    <input type="file" name="logo" id="logo" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700">
+                    <?php if (!empty($lycee['logo'])): ?>
+                        <div class="mt-2">
+                            <img src="<?= htmlspecialchars($lycee['logo']) ?>" alt="Logo" class="img-thumbnail" style="max-height: 50px;">
+                        </div>
+                    <?php endif; ?>
+                </div>
+
+                <div>
                     <label for="type_lycee" class="block text-gray-700 text-sm font-bold mb-2"><?= _('High School Type') ?></label>
                     <select name="type_lycee" id="type_lycee" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700" required>
                         <option value="public" <?= $lycee['type_lycee'] == 'public' ? 'selected' : '' ?>><?= _('Public') ?></option>
                         <option value="prive" <?= $lycee['type_lycee'] == 'prive' ? 'selected' : '' ?>><?= _('Private') ?></option>
-                        <option value="parapublic" <?= $lycee['type_lycee'] == 'parapublic' ? 'selected' : '' ?>><?= _('Parapublic') ?></option>
+                        <option value="semi-public" <?= $lycee['type_lycee'] == 'semi-public' || $lycee['type_lycee'] == 'parapublic' ? 'selected' : '' ?>><?= _('Semi-public') ?></option>
                     </select>
                 </div>
 

--- a/src/views/settings/index.php
+++ b/src/views/settings/index.php
@@ -32,7 +32,7 @@
                             </div>
                         <?php endif; ?>
 
-                        <form action="/settings" method="POST">
+                        <form action="/settings" method="POST" enctype="multipart/form-data">
                             <div class="row g-3">
                                 <div class="col-md-6">
                                     <label for="nom_lycee" class="form-label"><?= _('Nom du Lycée') ?></label>
@@ -40,12 +40,29 @@
                                 </div>
 
                                 <div class="col-md-6">
-                                    <label for="type_lycee" class="form-label"><?= _('Type de Lycée') ?></label>
-                                    <select name="type_lycee" id="type_lycee" class="form-select">
-                                        <option value="public" <?= ($settings['type_lycee'] ?? '') === 'public' ? 'selected' : '' ?>><?= _('Public') ?></option>
-                                        <option value="prive" <?= ($settings['type_lycee'] ?? '') === 'prive' ? 'selected' : '' ?>><?= _('Privé') ?></option>
-                                        <option value="parapublic" <?= ($settings['type_lycee'] ?? '') === 'parapublic' ? 'selected' : '' ?>><?= _('Parapublic') ?></option>
-                                    </select>
+                                    <label for="logo" class="form-label"><?= _('Logo du Lycée') ?></label>
+                                    <input type="file" name="logo" id="logo" class="form-control">
+                                    <?php if (!empty($settings['logo'])): ?>
+                                        <div class="mt-2">
+                                            <img src="<?= htmlspecialchars($settings['logo']) ?>" alt="Logo" class="img-thumbnail" style="max-height: 50px;">
+                                        </div>
+                                    <?php endif; ?>
+                                </div>
+
+                                <div class="col-md-6">
+                                    <label class="form-label d-block"><?= _('Type de Lycée') ?></label>
+                                    <div class="form-check form-check-inline">
+                                        <input class="form-check-input" type="radio" name="type_lycee" id="type_public" value="public" <?= ($settings['type_lycee'] ?? '') === 'public' ? 'checked' : '' ?>>
+                                        <label class="form-check-label" for="type_public"><?= _('Public') ?></label>
+                                    </div>
+                                    <div class="form-check form-check-inline">
+                                        <input class="form-check-input" type="radio" name="type_lycee" id="type_prive" value="prive" <?= ($settings['type_lycee'] ?? '') === 'prive' ? 'checked' : '' ?>>
+                                        <label class="form-check-label" for="type_prive"><?= _('Privé') ?></label>
+                                    </div>
+                                    <div class="form-check form-check-inline">
+                                        <input class="form-check-input" type="radio" name="type_lycee" id="type_semi" value="semi-public" <?= ($settings['type_lycee'] ?? '') === 'semi-public' || ($settings['type_lycee'] ?? '') === 'parapublic' ? 'checked' : '' ?>>
+                                        <label class="form-check-label" for="type_semi"><?= _('Semi-public') ?></label>
+                                    </div>
                                 </div>
 
                                 <div class="col-md-6">
@@ -66,12 +83,19 @@
                                 </div>
 
                                 <div class="col-12">
-                                    <label for="modalite_paiement" class="form-label"><?= _('Modalité de Paiement des Frais de Scolarité') ?></label>
-                                    <select name="modalite_paiement" id="modalite_paiement" class="form-select">
-                                        <option value="avant_inscription" <?= ($settings['modalite_paiement'] ?? '') === 'avant_inscription' ? 'selected' : '' ?>><?= _('Avant l\'inscription') ?></option>
-                                        <option value="apres_test" <?= ($settings['modalite_paiement'] ?? '') === 'apres_test' ? 'selected' : '' ?>><?= _('Après le test d\'entrée') ?></option>
-                                        <option value="fractionne" <?= ($settings['modalite_paiement'] ?? '') === 'fractionne' ? 'selected' : '' ?>><?= _('Paiement fractionné') ?></option>
-                                    </select>
+                                    <label class="form-label d-block"><?= _('Modalité de Paiement des Frais de Scolarité') ?></label>
+                                    <div class="form-check form-check-inline">
+                                        <input class="form-check-input" type="radio" name="modalite_paiement" id="mod_avant" value="avant_inscription" <?= ($settings['modalite_paiement'] ?? '') === 'avant_inscription' ? 'checked' : '' ?>>
+                                        <label class="form-check-label" for="mod_avant"><?= _('Avant l\'inscription') ?></label>
+                                    </div>
+                                    <div class="form-check form-check-inline">
+                                        <input class="form-check-input" type="radio" name="modalite_paiement" id="mod_apres" value="apres_test" <?= ($settings['modalite_paiement'] ?? '') === 'apres_test' ? 'checked' : '' ?>>
+                                        <label class="form-check-label" for="mod_apres"><?= _('Après le test d\'entrée') ?></label>
+                                    </div>
+                                    <div class="form-check form-check-inline">
+                                        <input class="form-check-input" type="radio" name="modalite_paiement" id="mod_frac" value="fractionne" <?= ($settings['modalite_paiement'] ?? '') === 'fractionne' ? 'checked' : '' ?>>
+                                        <label class="form-check-label" for="mod_frac"><?= _('Paiement fractionné') ?></label>
+                                    </div>
                                 </div>
 
                                 <div class="col-12 mt-4">

--- a/src/views/setup/step1_single.php
+++ b/src/views/setup/step1_single.php
@@ -9,7 +9,7 @@
                     <legend class="h5 fw-bold border-bottom pb-2 mb-3"><?= _('Informations sur l\'école') ?></legend>
                     <div class="row g-3">
                         <div class="col-md-6"><label for="nom_lycee" class="form-label"><?= _('Nom du Lycée') ?></label><input type="text" name="nom_lycee" id="nom_lycee" class="form-control" required></div>
-                        <div class="col-md-6"><label for="type_lycee" class="form-label"><?= _('Type de Lycée') ?></label><select name="type_lycee" id="type_lycee" class="form-select" required><option value="prive"><?= _('Privé') ?></option><option value="parapublic"><?= _('Parapublic') ?></option><option value="public"><?= _('Public') ?></option></select></div>
+                        <div class="col-md-6"><label for="type_lycee" class="form-label"><?= _('Type de Lycée') ?></label><select name="type_lycee" id="type_lycee" class="form-select" required><option value="prive"><?= _('Privé') ?></option><option value="semi-public"><?= _('Semi-public') ?></option><option value="public"><?= _('Public') ?></option></select></div>
                         <div class="col-12"><label for="annee_academique" class="form-label"><?= _('Année Académique Actuelle') ?></label><input type="text" name="annee_academique" id="annee_academique" class="form-control" placeholder="Ex: 2024-2025" required></div>
                     </div>
                 </fieldset>


### PR DESCRIPTION
This change addresses two major issues in the school settings:
1. **Logo Management**: Added logo upload and modification capability to the school settings page (`/settings`) and the high school management views.
2. **Settings Options**:
    - Converted school type and payment modality selection to radio buttons.
    - Ensured 'semi-public' is used consistently to match the database schema.
    - Added missing columns to the `param_general` table for feature toggles (multilingual, biometrics, national confidentiality).
    - Updated `SettingsController` and `ParamGeneral` model to correctly handle form data, including checkbox states.
    - Maintained application security by preserving XSS protection in the core `Validator`.

---
*PR created automatically by Jules for task [7068303285031600835](https://jules.google.com/task/7068303285031600835) started by @hassane-dev*