### PR TITLE
Conditional Student Registration and Payment Activation Workflow

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -52,6 +52,7 @@ CREATE TABLE `param_general` (
     `langue_2` VARCHAR(50),
     `sequence_annuelle` ENUM('Semestrielle', 'Trimestrielle') NOT NULL DEFAULT 'Trimestrielle',
     `mode_cycle` ENUM('lycee_unique', 'separe_ceg_lycee') NOT NULL DEFAULT 'separe_ceg_lycee',
+    `mensualite_obligatoire_inscription` BOOLEAN DEFAULT FALSE,
     `cree_le` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (`lycee_id`) REFERENCES `param_lycee`(`id`) ON DELETE CASCADE
 );
@@ -291,7 +292,7 @@ CREATE TABLE `eleves` (
     `photo` TEXT,
     `email` VARCHAR(255) UNIQUE,
     `telephone` VARCHAR(50),
-    `statut` ENUM('en_attente', 'actif', 'transféré', 'radié', 'diplômé', 'abandonné') NOT NULL DEFAULT 'en_attente',
+    `statut` ENUM('en_attente', 'en_attente_paiement', 'actif', 'transféré', 'radié', 'diplômé', 'abandonné') NOT NULL DEFAULT 'en_attente',
     FOREIGN KEY (`lycee_id`) REFERENCES `param_lycee`(`id`) ON DELETE CASCADE
 );
 

--- a/src/controllers/ComptableController.php
+++ b/src/controllers/ComptableController.php
@@ -3,6 +3,7 @@
 require_once __DIR__ . '/../models/Eleve.php';
 require_once __DIR__ . '/../models/Etude.php';
 require_once __DIR__ . '/../models/Frais.php';
+require_once __DIR__ . '/../models/Classe.php';
 require_once __DIR__ . '/../models/Inscription.php';
 require_once __DIR__ . '/../models/AnneeAcademique.php';
 require_once __DIR__ . '/../core/Auth.php';
@@ -44,7 +45,8 @@ class ComptableController {
         $etude = Etude::findPendingEnrollment($eleve_id, $activeYear['id']);
         if (!$etude) { die("Aucune inscription en attente trouvée pour cet élève cette année."); }
 
-        $frais = Frais::getForClasse($etude['classe_id'], $activeYear['id']);
+        $classe = Classe::findById($etude['classe_id']);
+        $frais = Frais::findForClasse($classe, $activeYear['id']);
 
         require_once __DIR__ . '/../views/comptable/validate.php';
     }
@@ -59,7 +61,8 @@ class ComptableController {
 
         $eleve = Eleve::findById($eleve_id);
         $activeYear = AnneeAcademique::findActive();
-        $frais = Frais::getForClasse($_POST['classe_id'], $activeYear['id']);
+        $classe = Classe::findById($_POST['classe_id']);
+        $frais = Frais::findForClasse($classe, $activeYear['id']);
 
         $montant_total = $frais['frais_inscription'];
         // Add other fees if they exist
@@ -76,7 +79,7 @@ class ComptableController {
             Eleve::save($eleve);
 
             // 3. Create the financial record (inscription)
-            Inscription::create([
+            Inscription::save([
                 'eleve_id' => $eleve_id,
                 'classe_id' => $_POST['classe_id'],
                 'lycee_id' => $eleve['lycee_id'],
@@ -84,8 +87,8 @@ class ComptableController {
                 'montant_total' => $montant_total,
                 'montant_verse' => $montant_verse,
                 'reste_a_payer' => $montant_total - $montant_verse,
-                'details_frais' => ['frais_inscription' => $frais['frais_inscription']],
-                'user_id' => Auth::get('id_user')
+                'details_frais' => json_encode(['frais_inscription' => $frais['frais_inscription']]),
+                'user_id' => Auth::get('id')
             ]);
 
             $db->commit();

--- a/src/controllers/ComptableController.php
+++ b/src/controllers/ComptableController.php
@@ -6,6 +6,7 @@ require_once __DIR__ . '/../models/Frais.php';
 require_once __DIR__ . '/../models/Inscription.php';
 require_once __DIR__ . '/../models/AnneeAcademique.php';
 require_once __DIR__ . '/../core/Auth.php';
+require_once __DIR__ . '/../core/View.php';
 
 class ComptableController {
 
@@ -20,13 +21,15 @@ class ComptableController {
 
     public function listPending() {
         $this->checkAccess();
-        $lycee_id = Auth::get('lycee_id');
+        $lycee_id = Auth::getLyceeId();
 
         // Find students in this lycee with 'en_attente_paiement' status
-        // This requires adding a new method to the Eleve model.
         $eleves_en_attente = Eleve::findByStatus('en_attente_paiement', $lycee_id);
 
-        require_once __DIR__ . '/../views/comptable/pending.php';
+        View::render('comptable/pending', [
+            'eleves_en_attente' => $eleves_en_attente,
+            'title' => 'Inscriptions en Attente'
+        ]);
     }
 
     public function showValidationForm() {

--- a/src/controllers/EleveController.php
+++ b/src/controllers/EleveController.php
@@ -107,12 +107,6 @@ class EleveController {
             Eleve::save($data);
             $eleve_id = $db->lastInsertId();
 
-            // Notification pour le comptable
-            $eleve_nom_complet = $data['prenom'] . ' ' . $data['nom'];
-            $message = "Un nouvel élève est en attente de paiement : {$eleve_nom_complet}. Cliquez pour procéder au paiement.";
-            $link = "/paiements/show/{$eleve_id}";
-            Notification::notifyRole('comptable', $data['lycee_id'], $message, $link);
-
             $db->commit();
 
         } catch (Exception $e) {
@@ -361,17 +355,38 @@ class EleveController {
                     throw new Exception("Aucune année académique active n'a été trouvée.");
                 }
 
+                // Get Lycee details to check type
+                require_once __DIR__ . '/../models/ParamLycee.php';
+                $lycee = ParamLycee::findByLyceeId($lycee_id);
+                $is_public = ($lycee['type_lycee'] === 'public');
+
+                $etude_active = $is_public ? 1 : 0;
+
                 // Create the study record
                 Etude::create([
                     'eleve_id' => $eleve_id,
                     'classe_id' => $classe_id,
                     'lycee_id' => $lycee_id,
                     'annee_academique_id' => $activeYear['id'],
-                    'actif' => 0 // Inactive until payment validation
+                    'actif' => $etude_active
                 ]);
 
                 // Increment the class's current number of students
                 Classe::incrementerEffectifActuel($classe_id, $activeYear['id']);
+
+                // If public, activate student immediately. Otherwise, set to 'en_attente_paiement'
+                if ($is_public) {
+                    Eleve::updateStatus($eleve_id, 'actif');
+                } else {
+                    Eleve::updateStatus($eleve_id, 'en_attente_paiement');
+
+                    // Notification pour le comptable
+                    $eleve = Eleve::findById($eleve_id);
+                    $eleve_nom_complet = $eleve['prenom'] . ' ' . $eleve['nom'];
+                    $message = "Un nouvel élève est en attente de paiement : {$eleve_nom_complet}. Cliquez pour procéder au paiement.";
+                    $link = "/paiements/show/{$eleve_id}";
+                    Notification::notifyRole('comptable', $lycee_id, $message, $link);
+                }
 
                 $db->commit();
 

--- a/src/controllers/PaiementController.php
+++ b/src/controllers/PaiementController.php
@@ -151,17 +151,8 @@ class PaiementController {
 
             Inscription::save($data);
 
-            // Si le paiement est complet, activer l'élève et l'étude
-            if ($resteAPayer <= 0) {
-                Eleve::updateStatus($eleveId, 'actif');
-                Etude::activate($etude['id_etude']);
-
-                // Notifier l'admin local que l'inscription est finalisée
-                $eleve_nom_complet = $eleve['prenom'] . ' ' . $eleve['nom'];
-                $message = "Paiement initial validé et inscription activée pour {$eleve_nom_complet}.";
-                $link = "/eleves/details?id={$eleveId}"; // Lien vers le profil de l'élève
-                Notification::notifyRole('admin_local', Auth::getLyceeId(), $message, $link);
-            }
+            // Vérifier et activer l'élève si possible
+            $this->checkAndActivateStudent($eleveId);
 
             $db->commit();
             $_SESSION['success_message'] = "Le paiement de l'inscription a été enregistré avec succès.";
@@ -218,6 +209,9 @@ class PaiementController {
                 }
             }
 
+            // Vérifier et activer l'élève si possible
+            $this->checkAndActivateStudent($eleveId);
+
             $db->commit();
             $_SESSION['success_message'] = "Les paiements des mensualités ont été enregistrés avec succès.";
 
@@ -228,5 +222,49 @@ class PaiementController {
 
         header('Location: /paiements/show/' . $eleveId);
         exit();
+    }
+
+    /**
+     * Vérifie si l'élève peut être activé selon les règles de paiement.
+     */
+    private function checkAndActivateStudent($eleveId) {
+        require_once __DIR__ . '/../models/ParamGeneral.php';
+        $lyceeId = Auth::getLyceeId();
+        $anneeActive = AnneeAcademique::findActive();
+
+        $params = ParamGeneral::findByLyceeId($lyceeId);
+        $eleve = Eleve::findById($eleveId);
+        $etude = Etude::findByEleveAndAnnee($eleveId, $anneeActive['id']);
+        $inscription = Inscription::findByEleveAndAnnee($eleveId, $anneeActive['id']);
+
+        // Si déjà actif, rien à faire
+        if ($eleve['statut'] === 'actif') {
+            return;
+        }
+
+        // L'inscription doit être totalement payée
+        $inscriptionComplete = ($inscription && $inscription['reste_a_payer'] <= 0);
+
+        if (!$inscriptionComplete) {
+            return;
+        }
+
+        // Si la mensualité est obligatoire, vérifier si au moins une mensualité est payée
+        if (!empty($params['mensualite_obligatoire_inscription'])) {
+            $mensualites = Mensualite::findByEleveAndAnnee($eleveId, $anneeActive['id']);
+            if (empty($mensualites)) {
+                return;
+            }
+        }
+
+        // Si on arrive ici, toutes les conditions sont remplies
+        Eleve::updateStatus($eleveId, 'actif');
+        Etude::activate($etude['id_etude']);
+
+        // Notifier l'admin local que l'élève est désormais actif
+        $eleve_nom_complet = $eleve['prenom'] . ' ' . $eleve['nom'];
+        $message = "L'élève {$eleve_nom_complet} est désormais actif après validation des paiements requis.";
+        $link = "/eleves/details?id={$eleveId}";
+        Notification::notifyRole('admin_local', $lyceeId, $message, $link);
     }
 }

--- a/src/controllers/SettingsController.php
+++ b/src/controllers/SettingsController.php
@@ -2,6 +2,7 @@
 
 require_once __DIR__ . '/../models/AnneeAcademique.php';
 require_once __DIR__ . '/../models/ParamGeneral.php';
+require_once __DIR__ . '/../models/ParamLycee.php';
 require_once __DIR__ . '/../core/Validator.php';
 require_once __DIR__ . '/../core/View.php';
 

--- a/src/models/Eleve.php
+++ b/src/models/Eleve.php
@@ -18,7 +18,7 @@ class Eleve {
                 LEFT JOIN classes c ON et.classe_id = c.id_classe
                 LEFT JOIN cycles cy ON c.cycle_id = cy.id_cycle
                 LEFT JOIN param_lycee l ON e.lycee_id = l.id
-                WHERE (e.statut = 'actif' OR e.statut = 'en_attente')";
+                WHERE (e.statut = 'actif' OR e.statut = 'en_attente' OR e.statut = 'en_attente_paiement')";
 
         $params = [];
 
@@ -192,6 +192,30 @@ class Eleve {
         $db = Database::getInstance();
         $stmt = $db->prepare("UPDATE eleves SET statut = :statut WHERE id_eleve = :id");
         return $stmt->execute(['id' => $id, 'statut' => $status]);
+    }
+
+    /**
+     * Trouve les élèves par statut et par lycée.
+     */
+    public static function findByStatus($status, $lycee_id = null) {
+        $db = Database::getInstance();
+        $sql = "SELECT e.*, c.niveau, c.serie, c.numero
+                FROM eleves e
+                LEFT JOIN etudes et ON e.id_eleve = et.eleve_id
+                    AND et.annee_academique_id = (SELECT id FROM annees_academiques WHERE est_active = 1 LIMIT 1)
+                LEFT JOIN classes c ON et.classe_id = c.id_classe
+                WHERE e.statut = :statut";
+        $params = ['statut' => $status];
+
+        if ($lycee_id) {
+            $sql .= " AND e.lycee_id = :lycee_id";
+            $params['lycee_id'] = $lycee_id;
+        }
+
+        $sql .= " ORDER BY e.nom, e.prenom ASC";
+        $stmt = $db->prepare($sql);
+        $stmt->execute($params);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }
 
     public static function findByClass($classe_id) {

--- a/src/models/ParamGeneral.php
+++ b/src/models/ParamGeneral.php
@@ -84,7 +84,8 @@ class ParamGeneral {
                     langue_1 = :langue_1,
                     langue_2 = :langue_2,
                     sequence_annuelle = :sequence_annuelle,
-                    mode_cycle = :mode_cycle
+                    mode_cycle = :mode_cycle,
+                    mensualite_obligatoire_inscription = :mensualite_obligatoire_inscription
                 WHERE lycee_id = :lycee_id";
 
         try {
@@ -99,6 +100,7 @@ class ParamGeneral {
                 'langue_2' => $data['langue_2'] ?? null,
                 'sequence_annuelle' => $data['sequence_annuelle'],
                 'mode_cycle' => $data['mode_cycle'] ?? 'separe_ceg_lycee',
+                'mensualite_obligatoire_inscription' => isset($data['mensualite_obligatoire_inscription']) ? 1 : 0,
                 'lycee_id' => $lycee_id
             ]);
         } catch (PDOException $e) {
@@ -124,7 +126,8 @@ class ParamGeneral {
                         langue_1 = :langue_1,
                         langue_2 = :langue_2,
                         sequence_annuelle = :sequence_annuelle,
-                        mode_cycle = :mode_cycle
+                        mode_cycle = :mode_cycle,
+                        mensualite_obligatoire_inscription = :mensualite_obligatoire_inscription
                     WHERE lycee_id = :lycee_id";
 
             $params = [
@@ -136,12 +139,13 @@ class ParamGeneral {
                 'langue_1' => $data['langue_1'] ?? $existing['langue_1'],
                 'langue_2' => $data['langue_2'] ?? $existing['langue_2'],
                 'sequence_annuelle' => $data['sequence_annuelle'] ?? $existing['sequence_annuelle'],
-                'mode_cycle' => $data['mode_cycle'] ?? $existing['mode_cycle']
+                'mode_cycle' => $data['mode_cycle'] ?? $existing['mode_cycle'],
+                'mensualite_obligatoire_inscription' => isset($data['mensualite_obligatoire_inscription']) ? 1 : ($existing['mensualite_obligatoire_inscription'] ?? 0)
             ];
         } else {
             // Create with defaults
-            $sql = "INSERT INTO param_general (lycee_id, devise_pays, monnaie, modalite_paiement, nb_langue, langue_1, langue_2, sequence_annuelle, mode_cycle)
-                    VALUES (:lycee_id, :devise_pays, :monnaie, :modalite_paiement, :nb_langue, :langue_1, :langue_2, :sequence_annuelle, :mode_cycle)";
+            $sql = "INSERT INTO param_general (lycee_id, devise_pays, monnaie, modalite_paiement, nb_langue, langue_1, langue_2, sequence_annuelle, mode_cycle, mensualite_obligatoire_inscription)
+                    VALUES (:lycee_id, :devise_pays, :monnaie, :modalite_paiement, :nb_langue, :langue_1, :langue_2, :sequence_annuelle, :mode_cycle, :mensualite_obligatoire_inscription)";
 
             $params = [
                 'lycee_id' => $data['lycee_id'],
@@ -152,7 +156,8 @@ class ParamGeneral {
                 'langue_1' => $data['langue_1'] ?? 'Francais',
                 'langue_2' => $data['langue_2'] ?? null,
                 'sequence_annuelle' => $data['sequence_annuelle'] ?? 'Trimestrielle',
-                'mode_cycle' => $data['mode_cycle'] ?? 'separe_ceg_lycee'
+                'mode_cycle' => $data['mode_cycle'] ?? 'separe_ceg_lycee',
+                'mensualite_obligatoire_inscription' => isset($data['mensualite_obligatoire_inscription']) ? 1 : 0
             ];
         }
 

--- a/src/views/comptable/pending.php
+++ b/src/views/comptable/pending.php
@@ -1,43 +1,68 @@
-<?php
-$title = "Inscriptions en Attente";
-ob_start();
-?>
+<?php require_once __DIR__ . '/../layouts/header_able.php'; ?>
+<?php require_once __DIR__ . '/../layouts/sidebar_able.php'; ?>
 
-<div class="container">
-    <h1>Inscriptions en Attente de Validation</h1>
-    <p>Liste des élèves qui ont été pré-inscrits et attendent la validation du paiement.</p>
+<div class="pc-container">
+    <div class="pc-content">
+        <div class="page-header">
+            <div class="page-block">
+                <div class="row align-items-center">
+                    <div class="col-md-12">
+                        <div class="page-header-title">
+                            <h2 class="mb-0"><?= $title ?></h2>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
 
-    <table class="table table-striped mt-4">
-        <thead>
-            <tr>
-                <th>Nom</th>
-                <th>Prénom</th>
-                <th>Date de Naissance</th>
-                <th>Actions</th>
-            </tr>
-        </thead>
-        <tbody>
-            <?php if (empty($eleves_en_attente)): ?>
-                <tr>
-                    <td colspan="4" class="text-center">Aucune inscription en attente.</td>
-                </tr>
-            <?php else: ?>
-                <?php foreach ($eleves_en_attente as $eleve): ?>
-                    <tr>
-                        <td><?= htmlspecialchars($eleve['nom']) ?></td>
-                        <td><?= htmlspecialchars($eleve['prenom']) ?></td>
-                        <td><?= htmlspecialchars($eleve['date_naissance']) ?></td>
-                        <td>
-                            <a href="/comptable/validate-form?eleve_id=<?= $eleve['id_eleve'] ?>" class="btn btn-primary btn-sm">Valider le Paiement</a>
-                        </td>
-                    </tr>
-                <?php endforeach; ?>
-            <?php endif; ?>
-        </tbody>
-    </table>
+        <div class="row">
+            <div class="col-sm-12">
+                <div class="card">
+                    <div class="card-header">
+                        <h5>Liste des élèves en attente de paiement</h5>
+                    </div>
+                    <div class="card-body">
+                        <div class="table-responsive">
+                            <table class="table table-hover">
+                                <thead>
+                                    <tr>
+                                        <th>Nom</th>
+                                        <th>Prénom</th>
+                                        <th>Classe</th>
+                                        <th>Action</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <?php if (empty($eleves_en_attente)): ?>
+                                        <tr>
+                                            <td colspan="4" class="text-center">Aucun élève en attente de paiement.</td>
+                                        </tr>
+                                    <?php else: ?>
+                                        <?php foreach ($eleves_en_attente as $eleve): ?>
+                                            <tr>
+                                                <td><?= htmlspecialchars($eleve['nom']) ?></td>
+                                                <td><?= htmlspecialchars($eleve['prenom']) ?></td>
+                                                <td>
+                                                    <?= htmlspecialchars($eleve['niveau']) ?>
+                                                    <?= !empty($eleve['serie']) ? htmlspecialchars($eleve['serie']) : '' ?>
+                                                    <?= htmlspecialchars($eleve['numero']) ?>
+                                                </td>
+                                                <td>
+                                                    <a href="/paiements/show/<?= $eleve['id_eleve'] ?>" class="btn btn-sm btn-primary">
+                                                        <i class="ph-duotone ph-currency-dollar"></i> Enregistrer Paiement
+                                                    </a>
+                                                </td>
+                                            </tr>
+                                        <?php endforeach; ?>
+                                    <?php endif; ?>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
 </div>
 
-<?php
-$content = ob_get_clean();
-require_once __DIR__ . '/../layouts/header.php';
-?>
+<?php require_once __DIR__ . '/../layouts/footer_able.php'; ?>

--- a/src/views/settings/index.php
+++ b/src/views/settings/index.php
@@ -87,6 +87,10 @@
                                         <input class="form-check-input" type="checkbox" name="confidentialite_nationale" value="1" id="confidentialite_nationale" <?= !empty($settings['confidentialite_nationale']) ? 'checked' : '' ?>>
                                         <label class="form-check-label" for="confidentialite_nationale"><?= _('Appliquer la confidentialité nationale') ?></label>
                                     </div>
+                                    <div class="form-check form-switch">
+                                        <input class="form-check-input" type="checkbox" name="mensualite_obligatoire_inscription" value="1" id="mensualite_obligatoire_inscription" <?= !empty($settings['mensualite_obligatoire_inscription']) ? 'checked' : '' ?>>
+                                        <label class="form-check-label" for="mensualite_obligatoire_inscription"><?= _('Exiger le paiement de la première mensualité à l\'inscription (Établissements Privés/Parapublics)') ?></label>
+                                    </div>
                                 </div>
                             </div>
 


### PR DESCRIPTION
This update implements a more robust registration workflow that differentiates between public and private/parapublic establishments. 

Key changes include:
1. **Database Schema**: Updated the `eleves` table to include the `en_attente_paiement` status and the `param_general` table to include a flag for mandatory monthly payment at registration.
2. **Settings**: Added a new toggle in the school settings to enforce the first monthly payment during the registration process for private schools.
3. **Registration Flow**: In `EleveController`, students registered in private or semi-public schools are now placed in 'waiting for payment' status until fees are validated. Public school students are activated immediately.
4. **Accountant Interface**: Migrated the pending registration list to the new 'Able Pro' theme, providing a clearer view for accountants to process incoming students.
5. **Activation Logic**: Centralized the student activation logic in `PaiementController`. An enrollment is now only activated when all financial requirements (registration fees + optional monthly fee) are satisfied.
6. **Notifications**: Integrated system notifications to alert accountants of new registrations needing validation and to inform administrators when a student becomes active.

---
*PR created automatically by Jules for task [16462967171593776233](https://jules.google.com/task/16462967171593776233) started by @hassane-dev*