### PR TITLE
Dynamic Series and Category fields in Class forms

### DIFF
--- a/src/controllers/ClasseController.php
+++ b/src/controllers/ClasseController.php
@@ -2,6 +2,7 @@
 
 require_once __DIR__ . '/../models/Classe.php';
 require_once __DIR__ . '/../models/Cycle.php';
+require_once __DIR__ . '/../models/Serie.php';
 require_once __DIR__ . '/../models/Lycee.php';
 require_once __DIR__ . '/../models/AnneeAcademique.php';
 require_once __DIR__ . '/../models/Matiere.php';
@@ -110,10 +111,12 @@ class ClasseController {
         $lycee_id = Auth::getLyceeId();
         $params = ParamGeneral::findByLyceeId($lycee_id);
         $mode_cycle = $params['mode_cycle'] ?? 'separe_ceg_lycee'; // Default value
+        $series = Serie::findAll($lycee_id);
 
         View::render('classes/create', [
             'cycles' => $cycles,
             'lycees' => $lycees,
+            'series' => $series,
             'mode_cycle' => $mode_cycle,
             'title' => 'Nouvelle Classe'
         ]);
@@ -171,6 +174,7 @@ class ClasseController {
 
         $cycles = Cycle::findAll();
         $lycees = Auth::can('view_all_lycees', 'lycee') ? Lycee::findAll() : [];
+        $series = Serie::findAll($classe['lycee_id']);
 
         // Add formatted name to the classe array
         $classe['nom_complet'] = Classe::getFormattedName($classe);
@@ -179,6 +183,7 @@ class ClasseController {
             'classe' => $classe,
             'cycles' => $cycles,
             'lycees' => $lycees,
+            'series' => $series,
             'title' => 'Modifier la Classe'
         ]);
     }

--- a/src/views/classes/create.php
+++ b/src/views/classes/create.php
@@ -45,13 +45,18 @@
                                 </div>
 
                                 <!-- Serie -->
-                                <div class="col-md-6">
+                                <div class="col-md-6" id="serie_container" style="display: none;">
                                     <label for="serie" class="form-label"><?= _('Série') ?></label>
-                                    <input type="text" name="serie" id="serie" class="form-control" placeholder="<?= _('Ex: A4') ?>">
+                                    <select name="serie" id="serie" class="form-select">
+                                        <option value=""><?= _('-- Choisir une série --') ?></option>
+                                        <?php foreach ($series as $serie): ?>
+                                            <option value="<?= htmlspecialchars($serie['nom_serie']) ?>" data-categorie="<?= htmlspecialchars($serie['categorie']) ?>"><?= htmlspecialchars($serie['nom_serie']) ?></option>
+                                        <?php endforeach; ?>
+                                    </select>
                                 </div>
 
                                 <!-- Categorie -->
-                                <div class="col-md-6">
+                                <div class="col-md-6" id="categorie_container" style="display: none;">
                                     <label for="categorie" class="form-label"><?= _('Catégorie') ?></label>
                                     <select name="categorie" id="categorie" class="form-select">
                                         <option value=""><?= _('-- Choisir une catégorie --') ?></option>
@@ -96,12 +101,14 @@
 </div>
 <!-- [ Main Content ] end -->
 
-<?php require_once __DIR__ . '/../layouts/footer_able.php'; ?>
-
 <script>
     document.addEventListener('DOMContentLoaded', function () {
         const cycleSelect = document.getElementById('cycle_id');
         const niveauSelect = document.getElementById('niveau');
+        const serieSelect = document.getElementById('serie');
+        const serieContainer = document.getElementById('serie_container');
+        const categorieSelect = document.getElementById('categorie');
+        const categorieContainer = document.getElementById('categorie_container');
 
         const niveauxParCycle = {
             'CEG': ['6e', '5e', '4e', '3e'],
@@ -111,7 +118,7 @@
         cycleSelect.addEventListener('change', function () {
             // Get the selected cycle's name from the data attribute
             const selectedOption = this.options[this.selectedIndex];
-            const nomCycle = selectedOption.getAttribute('data-nom-cycle');
+            const nomCycle = selectedOption ? selectedOption.getAttribute('data-nom-cycle') : '';
 
             // Clear previous options
             niveauSelect.innerHTML = '<option value=""><?= _('-- Choisir un niveau --') ?></option>';
@@ -131,6 +138,27 @@
                 // If no cycle is selected, disable the niveau select
                 niveauSelect.disabled = true;
             }
+
+            // Show/Hide Serie and Categorie based on Cycle
+            if (nomCycle === 'Lycée') {
+                serieContainer.style.display = 'block';
+                categorieContainer.style.display = 'block';
+            } else {
+                serieContainer.style.display = 'none';
+                categorieContainer.style.display = 'none';
+                serieSelect.value = '';
+                categorieSelect.value = '';
+            }
+        });
+
+        serieSelect.addEventListener('change', function () {
+            const selectedOption = this.options[this.selectedIndex];
+            const categorie = selectedOption.getAttribute('data-categorie');
+            if (categorie) {
+                categorieSelect.value = categorie;
+            }
         });
     });
 </script>
+
+<?php require_once __DIR__ . '/../layouts/footer_able.php'; ?>

--- a/src/views/classes/edit.php
+++ b/src/views/classes/edit.php
@@ -34,13 +34,18 @@
                                 </div>
 
                                 <!-- Serie -->
-                                <div class="col-md-6">
+                                <div class="col-md-6" id="serie_container">
                                     <label for="serie" class="form-label"><?= _('Série') ?></label>
-                                    <input type="text" name="serie" id="serie" class="form-control" value="<?= htmlspecialchars($classe['serie']) ?>">
+                                    <select name="serie" id="serie" class="form-select">
+                                        <option value=""><?= _('-- Choisir une série --') ?></option>
+                                        <?php foreach ($series as $serie): ?>
+                                            <option value="<?= htmlspecialchars($serie['nom_serie']) ?>" data-categorie="<?= htmlspecialchars($serie['categorie']) ?>" <?= ($classe['serie'] ?? '') == $serie['nom_serie'] ? 'selected' : '' ?>><?= htmlspecialchars($serie['nom_serie']) ?></option>
+                                        <?php endforeach; ?>
+                                    </select>
                                 </div>
 
                                 <!-- Categorie -->
-                                <div class="col-md-6">
+                                <div class="col-md-6" id="categorie_container">
                                     <label for="categorie" class="form-label"><?= _('Catégorie') ?></label>
                                     <select name="categorie" id="categorie" class="form-select">
                                         <option value=""><?= _('-- Choisir une catégorie --') ?></option>
@@ -60,7 +65,7 @@
                                     <label for="cycle_id" class="form-label"><?= _('Cycle') ?></label>
                                     <select name="cycle_id" id="cycle_id" class="form-select" required>
                                         <?php foreach ($cycles as $cycle): ?>
-                                            <option value="<?= $cycle['id_cycle'] ?>" <?= $classe['cycle_id'] == $cycle['id_cycle'] ? 'selected' : '' ?>>
+                                            <option value="<?= $cycle['id_cycle'] ?>" data-nom-cycle="<?= htmlspecialchars($cycle['nom_cycle']) ?>" <?= $classe['cycle_id'] == $cycle['id_cycle'] ? 'selected' : '' ?>>
                                                 <?= htmlspecialchars($cycle['nom_cycle']) ?>
                                             </option>
                                         <?php endforeach; ?>
@@ -99,5 +104,43 @@
     </div>
 </div>
 <!-- [ Main Content ] end -->
+
+<script>
+    document.addEventListener('DOMContentLoaded', function () {
+        const cycleSelect = document.getElementById('cycle_id');
+        const serieSelect = document.getElementById('serie');
+        const serieContainer = document.getElementById('serie_container');
+        const categorieSelect = document.getElementById('categorie');
+        const categorieContainer = document.getElementById('categorie_container');
+
+        function toggleSerieAndCategorie() {
+            const selectedOption = cycleSelect.options[cycleSelect.selectedIndex];
+            const nomCycle = selectedOption ? selectedOption.getAttribute('data-nom-cycle') : '';
+
+            if (nomCycle === 'Lycée') {
+                serieContainer.style.display = 'block';
+                categorieContainer.style.display = 'block';
+            } else {
+                serieContainer.style.display = 'none';
+                categorieContainer.style.display = 'none';
+                serieSelect.value = '';
+                categorieSelect.value = '';
+            }
+        }
+
+        cycleSelect.addEventListener('change', toggleSerieAndCategorie);
+
+        serieSelect.addEventListener('change', function () {
+            const selectedOption = this.options[this.selectedIndex];
+            const categorie = selectedOption ? selectedOption.getAttribute('data-categorie') : '';
+            if (categorie) {
+                categorieSelect.value = categorie;
+            }
+        });
+
+        // Initialize state on load
+        toggleSerieAndCategorie();
+    });
+</script>
 
 <?php require_once __DIR__ . '/../layouts/footer_able.php'; ?>


### PR DESCRIPTION
This PR improves the user experience when creating or editing classes by making the 'Série' and 'Catégorie' fields dynamic. 

Specifically:
- The 'Série' field is now a dropdown instead of a text input, with options retrieved from the `series` table.
- These fields only appear if the selected cycle is 'Lycée'.
- Choosing a 'Série' automatically populates the corresponding 'Catégorie'.
- Code structure follows the 'Able Pro' theme conventions, with scripts correctly placed before the footer.

---
*PR created automatically by Jules for task [15595959073369683621](https://jules.google.com/task/15595959073369683621) started by @hassane-dev*