### PR TITLE
Fix student assignment crash and context handling

### DIFF
--- a/src/controllers/EleveController.php
+++ b/src/controllers/EleveController.php
@@ -329,6 +329,7 @@ class EleveController {
         View::render('eleves/assign_class', [
             'eleve' => $eleve,
             'cycles' => $cycles,
+            'lycee_id' => $eleve['lycee_id'],
             'title' => 'Assigner une Classe'
         ]);
     }
@@ -342,7 +343,15 @@ class EleveController {
 
         $data = Validator::sanitize($_POST);
         $eleve_id = $data['eleve_id'];
-        $lycee_id = Auth::getLyceeId();
+
+        $eleve = Eleve::findById($eleve_id);
+        if (!$eleve) {
+            $_SESSION['error_message'] = "Élève non trouvé.";
+            header('Location: /eleves');
+            exit();
+        }
+
+        $lycee_id = $eleve['lycee_id'];
 
         $classe_id = Classe::findIdByDetails($lycee_id, $data['niveau'], $data['serie'] ?? null, $data['numero']);
 
@@ -358,7 +367,7 @@ class EleveController {
 
                 // Get school type
                 $lycee = ParamLycee::findByLyceeId($lycee_id);
-                $type_lycee = $lycee['type_lycee'] ?? 'prive';
+                $type_lycee = ($lycee && isset($lycee['type_lycee'])) ? $lycee['type_lycee'] : 'prive';
 
                 $is_active = 0;
                 $status = 'pending_payment';
@@ -380,10 +389,9 @@ class EleveController {
 
                 if ($is_active) {
                     Eleve::changeStatus($eleve_id, 'actif');
-                    Etude::activate($etude_id, Auth::get('id'));
+                    Etude::activate($etude_id, Auth::getUserId());
                 } else {
                     // Notification pour le comptable (seulement si non activé immédiatement)
-                    $eleve = Eleve::findById($eleve_id);
                     $eleve_nom_complet = $eleve['prenom'] . ' ' . $eleve['nom'];
                     $message = "Un nouvel élève est en attente de paiement : {$eleve_nom_complet}. Cliquez pour procéder au paiement.";
                     $link = "/paiements/show/{$eleve_id}";
@@ -396,10 +404,12 @@ class EleveController {
                 $db->commit();
 
                 $_SESSION['success_message'] = "L'élève a été assigné à la classe avec succès.";
-            } catch (Exception $e) {
-                $db->rollBack();
+            } catch (Throwable $e) {
+                if ($db->inTransaction()) {
+                    $db->rollBack();
+                }
                 error_log("Erreur lors de l'assignation de la classe : " . $e->getMessage());
-                $_SESSION['error_message'] = "Une erreur est survenue. L'assignation a été annulée.";
+                $_SESSION['error_message'] = "Une erreur est survenue lors de l'assignation : " . $e->getMessage();
                 header('Location: /eleves/assign-class?eleve_id=' . $eleve_id);
                 exit();
             }

--- a/src/views/eleves/assign_class.php
+++ b/src/views/eleves/assign_class.php
@@ -78,7 +78,11 @@ document.addEventListener('DOMContentLoaded', function() {
     const serieContainer = document.getElementById('serie-container');
     const serieSelect = document.getElementById('serie');
     const numeroSelect = document.getElementById('numero');
-    const lyceeId = <?= Auth::getLyceeId() ?>;
+    const lyceeId = <?= $lycee_id ?? 'null' ?>;
+
+    if (!lyceeId) {
+        console.error('School ID (lycee_id) is missing.');
+    }
 
     function resetSelect(select, defaultOptionText) {
         select.innerHTML = `<option value="">${defaultOptionText}</option>`;


### PR DESCRIPTION
This change fixes a crash that occurred when assigning a student to a class, particularly when performed by a super administrator who might not have a school ID in their session. It ensures the correct school context is used (from the student's record) and improves overall robustness with better error handling and proper method calls.

---
*PR created automatically by Jules for task [14891306399698671033](https://jules.google.com/task/14891306399698671033) started by @hassane-dev*