### PR TITLE
Fix student assignment crash and improve error feedback

### DIFF
--- a/src/views/eleves/assign_class.php
+++ b/src/views/eleves/assign_class.php
@@ -15,6 +15,14 @@
             </div>
         </div>
 
+        <?php if (isset($_SESSION['error_message'])): ?>
+            <div class="alert alert-danger alert-dismissible fade show" role="alert">
+                <?= $_SESSION['error_message'] ?>
+                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+            </div>
+            <?php unset($_SESSION['error_message']); ?>
+        <?php endif; ?>
+
         <div class="row">
             <div class="col-12">
                 <div class="card">


### PR DESCRIPTION
- Retrieve student record to ensure correct school context (lycee_id)
- Use Auth::getUserId() instead of Auth::get('id')
- Add error message display in assign_class.php view
- Improve error handling with Throwable and transaction checks
- Fix school type lookup fallback logic