### PR TITLE
Restore Academic Year Management Visibility and Functionality

### DIFF
--- a/src/controllers/HomeController.php
+++ b/src/controllers/HomeController.php
@@ -26,6 +26,10 @@ class HomeController {
             $navLinks[] = ['url' => '/boutique/articles', 'text' => _('Gérer la Boutique')];
         }
 
+        if (Auth::can('manage', 'annee_academique') || Auth::can('view_all_lycees', 'lycee')) {
+            $navLinks[] = ['url' => '/annees-academiques', 'text' => _('Gérer les Années Académiques')];
+        }
+
         if (Auth::can('edit', 'param_lycee')) {
             $navLinks[] = ['url' => '/modele-carte/edit', 'text' => _('Éditeur de Carte')];
         }

--- a/src/views/annees_academiques/index.php
+++ b/src/views/annees_academiques/index.php
@@ -72,7 +72,7 @@
                                                     <?php if (!$annee['est_active']): ?>
                                                         <form action="/annees-academiques/activate" method="POST" class="d-inline">
                                                             <input type="hidden" name="id" value="<?= $annee['id'] ?>">
-                                                            <button type-="submit" class="btn btn-sm btn-success" title="<?= _('Activer cette année') ?>">
+                                                            <button type="submit" class="btn btn-sm btn-success" title="<?= _('Activer cette année') ?>">
                                                                 <i class="ti ti-check"></i>
                                                             </button>
                                                         </form>

--- a/src/views/layouts/header_able.php
+++ b/src/views/layouts/header_able.php
@@ -139,12 +139,18 @@ $notification_count = count($unread_notifications);
                 <li class="dropdown pc-h-item">
                      <a class="pc-head-link dropdown-toggle arrow-none me-0" data-bs-toggle="dropdown" href="#" role="button" aria-haspopup="false" aria-expanded="false">
                         <i class="ph-duotone ph-calendar-blank"></i>
-                        <span><?= _('Année') ?>: <?= htmlspecialchars($active_year['libelle'] ?? 'N/A') ?></span>
+                        <span><?= _('Année') ?>: <?= htmlspecialchars($active_year['libelle'] ?? _('Non définie')) ?></span>
                     </a>
                     <div class="dropdown-menu dropdown-menu-end pc-h-dropdown">
-                        <?php foreach ($all_years as $year): ?>
-                            <a href="/settings/change-year?id=<?= $year['id'] ?>" class="dropdown-item <?= (isset($active_year['id']) && $year['id'] == $active_year['id']) ? 'active' : '' ?>"><?= htmlspecialchars($year['libelle']) ?></a>
-                        <?php endforeach; ?>
+                        <?php if (empty($all_years)): ?>
+                            <a href="/annees-academiques/create" class="dropdown-item text-danger"><?= _('Aucune année définie') ?></a>
+                        <?php else: ?>
+                            <?php foreach ($all_years as $year): ?>
+                                <a href="/settings/change-year?id=<?= $year['id'] ?>" class="dropdown-item <?= (isset($active_year['id']) && $year['id'] == $active_year['id']) ? 'active' : '' ?>"><?= htmlspecialchars($year['libelle']) ?></a>
+                            <?php endforeach; ?>
+                            <div class="dropdown-divider"></div>
+                            <a href="/annees-academiques" class="dropdown-item"><i class="ph-duotone ph-gear me-2"></i><?= _('Gérer les années') ?></a>
+                        <?php endif; ?>
                     </div>
                 </li>
 

--- a/src/views/settings/index.php
+++ b/src/views/settings/index.php
@@ -70,7 +70,7 @@
                                     <select name="annee_academique_id" id="annee_academique_id" class="form-select">
                                         <option value=""><?= _('-- Sélectionner une année --') ?></option>
                                         <?php foreach ($annees_academiques as $annee): ?>
-                                            <option value="<?= $annee['id'] ?>" <?= ($settings['annee_academique_id'] ?? '') == $annee['id'] ? 'selected' : '' ?>>
+                                            <option value="<?= $annee['id'] ?>" <?= (isset($active_year['id']) && $active_year['id'] == $annee['id']) ? 'selected' : '' ?>>
                                                 <?= htmlspecialchars($annee['libelle']) ?>
                                             </option>
                                         <?php endforeach; ?>


### PR DESCRIPTION
This PR restores the visibility and functionality of the academic year management module. 

Key changes:
1. **Dashboard:** Added a quick access link for administrators to manage academic years directly from the home page.
2. **Settings:** Fixed the 'Active Academic Year' dropdown to correctly show the currently active year.
3. **Academic Year List:** Fixed a typo in the 'Activate' button that prevented it from working (changed `type-="submit"` to `type="submit"`).
4. **Header:** Improved the header to display 'Non définie' instead of 'N/A' when no year is active, and added a 'Gérer les années' link directly in the year selector dropdown for easier access.
5. **Cleanup:** Removed a temporary log file from the codebase.

---
*PR created automatically by Jules for task [1495776962087839232](https://jules.google.com/task/1495776962087839232) started by @hassane-dev*