### PR TITLE
fix(auth): fix argument order in Auth::can calls for accounting module

### DIFF
--- a/src/controllers/PaiementController.php
+++ b/src/controllers/PaiementController.php
@@ -15,7 +15,7 @@ require_once __DIR__ . '/../core/View.php';
 class PaiementController {
 
     private function checkAccess($action = 'manage') {
-        if (!Auth::can('paiement', $action)) {
+        if (!Auth::can($action, 'paiement')) {
             http_response_code(403);
             View::render('errors/403');
             exit();
@@ -269,7 +269,7 @@ class PaiementController {
             'options' => $options,
             'tranches' => $tranches,
             'mensualitesPayees' => $mensualitesPayees,
-            'isComptable' => Auth::can('paiement', 'manage')
+            'isComptable' => Auth::can('manage', 'paiement')
         ]);
     }
 

--- a/src/views/eleves/index.php
+++ b/src/views/eleves/index.php
@@ -134,7 +134,7 @@
                                                             <i class="ph-duotone ph-shopping-cart"></i>
                                                         </a>
                                                     <?php endif; ?>
-                                                    <?php if (Auth::can('paiement', 'view')): ?>
+                                                    <?php if (Auth::can('view', 'paiement')): ?>
                                                         <a href="/paiements/show/<?= $eleve['id_eleve'] ?>" class="btn btn-success btn-sm" title="<?= _('Gérer les paiements') ?>"><?= _('Payer') ?></a>
                                                     <?php endif; ?>
                                                     <a href="/eleves/details?id=<?= $eleve['id_eleve'] ?>" class="btn btn-info btn-sm ms-2" title="<?= _('Dossier complet') ?>"><?= _('Détails') ?></a>

--- a/src/views/layouts/sidebar_able.php
+++ b/src/views/layouts/sidebar_able.php
@@ -170,7 +170,7 @@ $navItems = [
         'icon' => 'ph-duotone ph-receipt',
         'text' => _('Paiements'),
         'title' => _('Enregistrer les paiements des frais scolaires.'),
-        'condition' => Auth::can('paiement', 'view'),
+        'condition' => Auth::can('view', 'paiement'),
     ],
     [
         'url' => '/salaires',


### PR DESCRIPTION
- Corrected Auth::can('view', 'paiement') in sidebar and controllers.
- Fixed 403 access denied error for accountants.
- Ensured consistent permission checking across the financial workstation.