### PR TITLE
Allow local admin to modify permissions of global roles

### DIFF
--- a/src/controllers/RoleController.php
+++ b/src/controllers/RoleController.php
@@ -80,12 +80,22 @@ class RoleController {
         $role = Role::findById($id);
         if (!$role) { header('Location: /roles'); exit(); }
 
-        // Security check for local admins: they can only edit roles for their own lycee.
-        // They cannot edit global roles (where lycee_id is NULL).
-        if (Auth::get('role_name') === 'admin_local' && $role['lycee_id'] != Auth::getLyceeId()) {
-             http_response_code(403);
-             View::render('errors/403');
-             exit();
+        // Security check for local admins: they can edit roles for their own lycee.
+        // They can also edit global roles if they have role:manage permission (which they do).
+        // However, we MUST prevent them from editing critical super admin roles.
+        if (Auth::get('role_name') === 'admin_local') {
+             // Block editing of Super Admin Creator (1) and Super Admin National (2)
+             if ($role['id_role'] == 1 || $role['id_role'] == 2) {
+                 http_response_code(403);
+                 View::render('errors/403');
+                 exit();
+             }
+             // Also block if it belongs to another school
+             if ($role['lycee_id'] !== null && $role['lycee_id'] != Auth::getLyceeId()) {
+                 http_response_code(403);
+                 View::render('errors/403');
+                 exit();
+             }
         }
 
         $permissions = Permission::findAll();
@@ -114,12 +124,35 @@ class RoleController {
             exit();
         }
 
-        // Security check for local admins: they can only update roles for their own lycee.
+        // Security check for local admins:
         $role = Role::findById($role_id);
-        if (!$role || (Auth::get('role_name') === 'admin_local' && $role['lycee_id'] != Auth::getLyceeId())) {
-            http_response_code(403);
-            View::render('errors/403');
+        if (!$role) {
+            http_response_code(404);
             exit();
+        }
+
+        if (Auth::get('role_name') === 'admin_local') {
+            // Block update of Super Admin roles
+            if ($role['id_role'] == 1 || $role['id_role'] == 2) {
+                http_response_code(403);
+                View::render('errors/403');
+                exit();
+            }
+            // Block update of roles belonging to other schools
+            if ($role['lycee_id'] !== null && $role['lycee_id'] != Auth::getLyceeId()) {
+                http_response_code(403);
+                View::render('errors/403');
+                exit();
+            }
+        }
+
+        // Re-read data to ensure any local admin overrides aren't lost if we moved the data gathering
+        $data = Validator::sanitize($_POST);
+
+        if (Auth::get('role_name') === 'admin_local') {
+            // Force lycee_id to remain as it is if they are not super admin
+            // (Local admin cannot make a local role global or change its school)
+            $data['lycee_id'] = $role['lycee_id'];
         }
 
         $db = Database::getInstance();

--- a/src/views/roles/edit.php
+++ b/src/views/roles/edit.php
@@ -32,7 +32,10 @@
                                     <h5 class="border-bottom pb-2 mb-3"><?= _('Détails du Rôle') ?></h5>
                                     <div class="mb-3">
                                         <label for="nom_role" class="form-label"><?= _('Nom du Rôle') ?></label>
-                                        <input type="text" name="nom_role" id="nom_role" class="form-control" value="<?= htmlspecialchars($role['nom_role'] ?? '') ?>" required>
+                                        <input type="text" name="nom_role" id="nom_role" class="form-control" value="<?= htmlspecialchars($role['nom_role'] ?? '') ?>" required <?= ($role['id_role'] <= 8 && Auth::get('role_name') === 'admin_local') ? 'readonly' : '' ?>>
+                                        <?php if ($role['id_role'] <= 8 && Auth::get('role_name') === 'admin_local'): ?>
+                                            <div class="form-text text-warning"><?= _('Le nom des rôles par défaut ne peut pas être modifié.') ?></div>
+                                        <?php endif; ?>
                                     </div>
 
                                     <?php if (Auth::can('view_all_lycees', 'lycee')): ?>

--- a/src/views/roles/index.php
+++ b/src/views/roles/index.php
@@ -57,14 +57,38 @@
                                                     <?= $role['lycee_id'] ? htmlspecialchars($role['nom_lycee']) : _('Global') ?>
                                                 </td>
                                                 <td class="text-end">
-                                                    <?php if ($role['id_role'] > 6): // Basic protection for default roles ?>
-                                                        <a href="/roles/edit?id=<?= $role['id_role'] ?>" class="btn btn-sm btn-primary ms-2"><?= _('Modifier') ?></a>
-                                                        <form action="/roles/destroy" method="POST" class="d-inline ms-2" onsubmit="return confirm('<?= _('Êtes-vous sûr ?') ?>');">
-                                                            <input type="hidden" name="id" value="<?= $role['id_role'] ?>">
-                                                            <button type="submit" class="btn btn-sm btn-danger"><?= _('Supprimer') ?></button>
-                                                        </form>
+                                                    <?php
+                                                    $user_role_name = Auth::get('role_name');
+                                                    $is_local_admin = ($user_role_name === 'admin_local');
+                                                    $is_super_admin = ($user_role_name === 'super_admin_createur' || $user_role_name === 'super_admin_national');
+
+                                                    $target_role_id = $role['id_role'];
+                                                    $is_target_super_admin = in_array($target_role_id, [1, 2]);
+                                                    $is_target_default = $target_role_id <= 8;
+
+                                                    // Determine if current user can edit this role
+                                                    $can_edit = false;
+                                                    if ($is_super_admin) {
+                                                        $can_edit = true; // Super admin can edit everything
+                                                    } elseif ($is_local_admin) {
+                                                        // Local admin can edit non-super-admin roles
+                                                        if (!$is_target_super_admin) {
+                                                            $can_edit = true;
+                                                        }
+                                                    }
+
+                                                    if ($can_edit): ?>
+                                                        <a href="/roles/edit?id=<?= $target_role_id ?>" class="btn btn-sm btn-primary ms-2">
+                                                            <?= $is_target_default ? _('Modifier Permissions') : _('Modifier') ?>
+                                                        </a>
+                                                        <?php if (!$is_target_default): ?>
+                                                            <form action="/roles/destroy" method="POST" class="d-inline ms-2" onsubmit="return confirm('<?= _('Êtes-vous sûr ?') ?>');">
+                                                                <input type="hidden" name="id" value="<?= $target_role_id ?>">
+                                                                <button type="submit" class="btn btn-sm btn-danger"><?= _('Supprimer') ?></button>
+                                                            </form>
+                                                        <?php endif; ?>
                                                     <?php else: ?>
-                                                        <a href="/roles/edit?id=<?= $role['id_role'] ?>" class="btn btn-sm btn-info"><?= _('Voir les Permissions') ?></a>
+                                                        <span class="badge bg-light-secondary"><?= _('Protégé') ?></span>
                                                     <?php endif; ?>
                                                 </td>
                                             </tr>


### PR DESCRIPTION
This change allows local administrators to modify the permissions of global roles (like 'comptable', 'enseignant', etc.) while still protecting critical Super Admin roles from being modified by local admins. It also ensures UI consistency between Super Admin and Local Admin views.

---
*PR created automatically by Jules for task [2257428111466063983](https://jules.google.com/task/2257428111466063983) started by @hassane-dev*