### PR TITLE
Add missing recu_numero column to inscriptions table

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -354,6 +354,7 @@ CREATE TABLE `inscriptions` (
     `reste_a_payer` DECIMAL(10, 2) NOT NULL,
     `details_frais` JSON,
     `user_id` INT,
+    `recu_numero` VARCHAR(50),
     `date_inscription` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (`etude_id`) REFERENCES `etudes`(`id_etude`) ON DELETE CASCADE,
     FOREIGN KEY (`eleve_id`) REFERENCES `eleves`(`id_eleve`) ON DELETE CASCADE,


### PR DESCRIPTION
The `recu_numero` column was missing from the `inscriptions` table in `db/schema.sql`, although the application code expected it to be there for tracking receipt numbers on registration payments. This caused an SQL error when trying to view or process payments. I have added the column to the table definition in the schema file. Additionally, I attempted to run the migration script, which failed due to the environment's lack of a running database server, but the source of truth in the schema file is now corrected.

---
*PR created automatically by Jules for task [12006995197511630561](https://jules.google.com/task/12006995197511630561) started by @hassane-dev*