### PR TITLE
Fix Student Registration Bug and Matricule Clarification

### DIFF
--- a/src/models/Eleve.php
+++ b/src/models/Eleve.php
@@ -86,7 +86,8 @@ class Eleve {
         $params = [];
         foreach ($fields as $field) {
             if (isset($data[$field])) {
-                $params[$field] = $data[$field];
+                // Convert empty strings to NULL for optional fields to avoid UNIQUE constraint issues (like email)
+                $params[$field] = ($data[$field] === '') ? null : $data[$field];
             } elseif ($isUpdate) {
                 // Keep current value if not provided during update
                 $params[$field] = $currentData[$field];
@@ -213,6 +214,27 @@ class Eleve {
             $sql .= " AND lycee_id = :lycee_id";
             $params['lycee_id'] = $lycee_id;
         }
+        $stmt = $db->prepare($sql);
+        $stmt->execute($params);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    /**
+     * Recherche des élèves par matricule, nom ou prénom.
+     * @param string $term
+     * @param int|null $lycee_id
+     * @return array
+     */
+    public static function search($term, $lycee_id = null) {
+        $db = Database::getInstance();
+        $sql = "SELECT * FROM eleves WHERE (nom LIKE :term OR prenom LIKE :term OR CAST(id_eleve AS CHAR) LIKE :term)";
+        $params = ['term' => '%' . $term . '%'];
+
+        if ($lycee_id) {
+            $sql .= " AND lycee_id = :lycee_id";
+            $params['lycee_id'] = $lycee_id;
+        }
+
         $stmt = $db->prepare($sql);
         $stmt->execute($params);
         return $stmt->fetchAll(PDO::FETCH_ASSOC);


### PR DESCRIPTION
This PR fixes a bug in the student registration process where attempting to register a second student without an email address resulted in a 403-like redirection (erreur=1) due to a UNIQUE constraint violation in the database. 

The fix ensures that empty optional fields are saved as NULL rather than empty strings. 

Additionally, I have:
- Implemented the missing `Eleve::search` method required by the reinscription module.
- Verified that student identifiers (matricules) are numeric, as they are based on the `id_eleve` auto-increment field.

---
*PR created automatically by Jules for task [8886446383408091980](https://jules.google.com/task/8886446383408091980) started by @hassane-dev*