### PR TITLE
Fix accounting workflow: unified receipts and notification clearing

### DIFF
--- a/src/controllers/PaiementController.php
+++ b/src/controllers/PaiementController.php
@@ -404,6 +404,9 @@ class PaiementController {
                 throw new Exception("Aucun montant à encaisser n'a été saisi.");
             }
 
+            // Marquer les notifications "En attente de paiement" comme traitées
+            Notification::markAsReadByLink("/paiements/show/{$eleveId}", $lyceeId);
+
             $db->commit();
             $_SESSION['success_message'] = "Opération d'encaissement réussie. Reçu N° {$reference}";
 

--- a/src/controllers/RecuController.php
+++ b/src/controllers/RecuController.php
@@ -27,6 +27,20 @@ class RecuController {
         }
         $inscription = $inscriptions[0];
 
+        // Récupérer les mensualités liées au même reçu
+        $mensualites = [];
+        if (!empty($inscription['recu_numero'])) {
+            $db = Database::getInstance();
+            $stmt = $db->prepare("
+                SELECT md.*, m.mois_ou_sequence
+                FROM mensualite_details md
+                JOIN mensualites m ON md.mensualite_id = m.id_mensualite
+                WHERE md.recu_numero = :recu
+            ");
+            $stmt->execute(['recu' => $inscription['recu_numero']]);
+            $mensualites = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        }
+
         $lycee = ParamLycee::findByLyceeId($eleve['lycee_id']);
         $caissier = User::findById($inscription['user_id']);
 

--- a/src/models/Notification.php
+++ b/src/models/Notification.php
@@ -54,6 +54,19 @@ class Notification {
     }
 
     /**
+     * Mark notifications as read for a specific link and lycee.
+     * Useful to clear "Pending" notifications once the action is performed.
+     * @param string $link
+     * @param int $lycee_id
+     * @return bool
+     */
+    public static function markAsReadByLink($link, $lycee_id) {
+        $db = Database::getInstance();
+        $stmt = $db->prepare("UPDATE notifications SET is_read = 1 WHERE link = :link AND lycee_id = :lycee_id");
+        return $stmt->execute(['link' => $link, 'lycee_id' => $lycee_id]);
+    }
+
+    /**
      * Find unread notifications for a user.
      * @param int $user_id
      * @return array

--- a/src/views/recus/inscription.php
+++ b/src/views/recus/inscription.php
@@ -62,14 +62,16 @@
             <p><?= htmlspecialchars(($lycee['quartier'] ?? '') . ' ' . ($lycee['ville'] ?? '')) ?> - BP: <?= htmlspecialchars($lycee['boite_postale'] ?? 'N/A') ?></p>
             <p>Tel: <?= htmlspecialchars($lycee['tel'] ?? '') ?> / Email: <?= htmlspecialchars($lycee['email'] ?? '') ?></p>
             </div>
-            <div style="width: 100px; text-align: right;">
+            <div style="width: 120px; text-align: right;">
                 <span class="info-label">N° Reçu</span>
-                <span class="info-value" style="font-size: 16px; color: #d9534f;">INS-<?= str_pad($inscription['id_inscription'], 5, '0', STR_PAD_LEFT) ?></span>
+                <span class="info-value" style="font-size: 16px; color: #d9534f;">
+                    <?= !empty($inscription['recu_numero']) ? htmlspecialchars($inscription['recu_numero']) : 'INS-' . str_pad($inscription['id_inscription'], 5, '0', STR_PAD_LEFT) ?>
+                </span>
             </div>
         </div>
 
         <div class="receipt-title">
-            <h2>Reçu de Frais d'Inscription</h2>
+            <h2>Reçu de Paiement</h2>
         </div>
 
         <div class="info-section">
@@ -95,33 +97,50 @@
             <thead>
                 <tr>
                     <th>Désignation des frais</th>
-                    <th style="text-align: right;">Montant Total</th>
                     <th style="text-align: right;">Montant Versé</th>
-                    <th style="text-align: right;">Reste à payer</th>
                 </tr>
             </thead>
             <tbody>
+                <?php $totalVerseOperation = (float)$inscription['montant_verse']; ?>
                 <tr>
                     <td>
-                        Frais d'inscription annuel<br>
+                        <strong>Frais d'inscription annuel</strong><br>
                         <small style="color: #666;">
-                            Options:
-                            - Logo: <?= !empty(json_decode($inscription['details_frais'], true)['logo']) ? 'OUI' : 'NON' ?>
-                            - Carte: <?= !empty(json_decode($inscription['details_frais'], true)['carte']) ? 'OUI' : 'NON' ?>
+                            Options incluses :
+                            Logo: <?= !empty(json_decode($inscription['details_frais'], true)['logo']) ? 'OUI' : 'NON' ?> |
+                            Carte: <?= !empty(json_decode($inscription['details_frais'], true)['carte']) ? 'OUI' : 'NON' ?>
                         </small>
                     </td>
-                    <td style="text-align: right;"><?= number_format($inscription['montant_total'], 0, ',', ' ') ?></td>
-                    <td style="text-align: right; font-weight: bold;"><?= number_format($inscription['montant_verse'], 0, ',', ' ') ?></td>
-                    <td style="text-align: right; color: <?= $inscription['reste_a_payer'] > 0 ? '#d9534f' : '#5cb85c' ?>; font-weight: bold;">
-                        <?= number_format($inscription['reste_a_payer'], 0, ',', ' ') ?> FCFA
-                    </td>
+                    <td style="text-align: right; font-weight: bold;"><?= number_format($inscription['montant_verse'], 0, ',', ' ') ?> FCFA</td>
                 </tr>
+
+                <?php foreach ($mensualites as $m): ?>
+                    <?php $totalVerseOperation += (float)$m['montant']; ?>
+                    <tr>
+                        <td>
+                            Scolarité - Mois de <strong><?= htmlspecialchars($m['mois_ou_sequence']) ?></strong>
+                        </td>
+                        <td style="text-align: right; font-weight: bold;"><?= number_format($m['montant'], 0, ',', ' ') ?> FCFA</td>
+                    </tr>
+                <?php endforeach; ?>
             </tbody>
+            <tfoot>
+                <tr style="background: #f0f0f0;">
+                    <td style="text-align: right; font-weight: bold; text-transform: uppercase;">Total versé lors de l'opération</td>
+                    <td style="text-align: right; font-weight: bold; font-size: 16px; border-left: 2px solid #333;"><?= number_format($totalVerseOperation, 0, ',', ' ') ?> FCFA</td>
+                </tr>
+            </tfoot>
         </table>
+
+        <?php if ($inscription['reste_a_payer'] > 0): ?>
+            <div style="margin-bottom: 20px; text-align: right; color: #d9534f; font-weight: bold;">
+                Reliquat sur inscription : <?= number_format($inscription['reste_a_payer'], 0, ',', ' ') ?> FCFA
+            </div>
+        <?php endif; ?>
 
         <div class="amount-words">
             <strong>Arrêté le présent reçu à la somme de :</strong><br>
-            <span style="text-transform: capitalize;"><?= number_format($inscription['montant_verse'], 0, ',', ' ') ?> Francs CFA</span>
+            <span style="text-transform: capitalize; font-weight: bold;"><?= number_format($totalVerseOperation, 0, ',', ' ') ?> Francs CFA</span>
         </div>
 
         <div class="footer">


### PR DESCRIPTION
This PR addresses two critical issues in the accounting workflow for new student registrations:

1. **Unified Receipts**: Previously, the registration receipt only showed the registration fee, even if monthly installments were paid in the same transaction. The system now links these payments via a shared `recu_numero` and displays them together on a single, comprehensive receipt.
2. **Automatic Notification Clearing**: Accountants were receiving notifications for students awaiting payment, but these notifications remained active even after the payment was completed. The system now automatically marks these specific notifications as read once the `processPayment` action is successfully executed.

---
*PR created automatically by Jules for task [5543637514794580402](https://jules.google.com/task/5543637514794580402) started by @hassane-dev*