### PR TITLE
Fix Fatal error: undefined method Classe::findByLycee() and Matiere::…

### DIFF
--- a/src/controllers/DeblocageController.php
+++ b/src/controllers/DeblocageController.php
@@ -33,8 +33,8 @@ class DeblocageController {
     public function create() {
         $this->checkAccess();
 
-        $classes = Classe::findByLycee(Auth::getLyceeId());
-        $matieres = Matiere::findByLycee(Auth::getLyceeId());
+        $classes = Classe::findAll(Auth::getLyceeId());
+        $matieres = Matiere::findAll();
         $enseignants = User::findTeachers(Auth::getLyceeId());
         $sequences = Sequence::findAll();
 


### PR DESCRIPTION
…findByLycee() in DeblocageController.php

The DeblocageController was calling non-existent methods findByLycee on Classe and Matiere models. These have been updated to use the correct findAll() methods.