### PR TITLE
Fix class ID lookup routing conflict and prevent infinite loops in pa…

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -119,7 +119,7 @@ $router->register('/classes/updateParams', 'ClasseController', 'updateParams');
 $router->register('/classes/get-niveaux', 'ClasseController', 'getNiveauxForCycle');
 $router->register('/classes/get-series', 'ClasseController', 'getSeriesForNiveau');
 $router->register('/classes/get-numeros', 'ClasseController', 'getNumerosForClasse');
-$router->register('/classes/show', 'ClasseController', 'findClassId');
+$router->register('/classes/find-id', 'ClasseController', 'findClassId');
 
 // Matieres CRUD
 $router->register('/matieres', 'MatiereController', 'index');

--- a/src/controllers/PaiementController.php
+++ b/src/controllers/PaiementController.php
@@ -279,9 +279,11 @@ class PaiementController {
             $current = new DateTime($sequence['date_debut']);
             $end = new DateTime($sequence['date_fin']);
 
-            while ($current <= $end) {
+            $safety = 0;
+            while ($current <= $end && $safety < 12) {
                 $mois[] = ucfirst($fmt->format($current));
                 $current->modify('first day of next month');
+                $safety++;
             }
 
             $paye = [];
@@ -364,9 +366,11 @@ class PaiementController {
         foreach ($sequences as $seq) {
             $current = new DateTime($seq['date_debut']);
             $end = new DateTime($seq['date_fin']);
-            while ($current <= $end && $current <= $today) {
+            $safety = 0;
+            while ($current <= $end && $current <= $today && $safety < 12) {
                 $monthsToDate[] = ucfirst($fmt->format($current));
                 $current->modify('first day of next month');
+                $safety++;
             }
         }
 

--- a/src/views/mensualites/index.php
+++ b/src/views/mensualites/index.php
@@ -163,7 +163,7 @@ document.addEventListener('DOMContentLoaded', function() {
             // Simplified: we'll call a helper to get ID or change route to use params.
             // Better: update the index.php to have a findClassId route or similar.
 
-            fetch(`/classes/show?lycee_id=${lyceeId}&niveau=${niveau}&serie=${serie}&numero=${numero}`)
+            fetch(`/classes/find-id?lycee_id=${lyceeId}&niveau=${niveau}&serie=${serie}&numero=${numero}`)
             .then(r => r.json())
             .then(classe => {
                 if(classe && classe.id_classe) {


### PR DESCRIPTION
…yment view

- Renamed `/classes/show` API route to `/classes/find-id` to avoid conflict with the class details view.
- Updated `src/views/mensualites/index.php` to use the new API route.
- Added safety counters to `while` loops in `PaiementController::show` and `PaiementController::restes` to prevent infinite loops if sequence dates are misconfigured.