### PR TITLE
Fix Undefined key "cycle_id" in Frais::findForClasse

### DIFF
--- a/src/controllers/PaiementController.php
+++ b/src/controllers/PaiementController.php
@@ -349,7 +349,7 @@ class PaiementController {
         // 2. Restes de mensualités
         // On récupère tous les élèves actifs
         $stmt = $db->prepare("
-            SELECT e.id_eleve, e.nom, e.prenom, c.id_classe, c.niveau, c.serie, c.numero, et.id_etude
+            SELECT e.id_eleve, e.nom, e.prenom, c.id_classe, c.niveau, c.serie, c.numero, c.cycle_id, c.lycee_id, et.id_etude
             FROM eleves e
             JOIN etudes et ON e.id_eleve = et.eleve_id
             JOIN classes c ON et.classe_id = c.id_classe

--- a/src/models/Frais.php
+++ b/src/models/Frais.php
@@ -123,10 +123,17 @@ class Frais {
      * @return array|false
      */
     public static function findForClasse($classe, $annee_academique_id) {
+        if (!$classe || !isset($classe['cycle_id']) || !isset($classe['lycee_id'])) {
+            return false;
+        }
+
         $db = Database::getInstance();
 
         // La classe contient déjà lycee_id, niveau, serie. Il faut juste le nom du cycle.
         $cycle = Cycle::findById($classe['cycle_id']);
+        if (!$cycle) {
+            return false;
+        }
         $nom_cycle = $cycle['nom_cycle'];
 
         $all_frais_sql = "SELECT * FROM frais


### PR DESCRIPTION
- Updated PaiementController::restes to include cycle_id and lycee_id in student query.
- Added defensive checks in Frais::findForClasse for required array keys and valid cycle lookup.