### PR TITLE
fix: add missing Classe and User model requirements in RecuController

### DIFF
--- a/src/controllers/RecuController.php
+++ b/src/controllers/RecuController.php
@@ -5,6 +5,8 @@ require_once __DIR__ . '/../models/Inscription.php';
 require_once __DIR__ . '/../models/Mensualite.php';
 require_once __DIR__ . '/../models/Lycee.php';
 require_once __DIR__ . '/../models/ParamLycee.php';
+require_once __DIR__ . '/../models/Classe.php';
+require_once __DIR__ . '/../models/User.php';
 require_once __DIR__ . '/../core/Auth.php';
 
 class RecuController {


### PR DESCRIPTION
Resolved a Fatal Error: "Uncaught Error: Class 'Classe' not found" in RecuController.php. The controller was using the Classe model without requiring it. Also added User model requirement as it is also used in the controller.