### PR TITLE
Fix fatal error: Class "ParamLycee" not found in CarteController

### DIFF
--- a/src/controllers/CarteController.php
+++ b/src/controllers/CarteController.php
@@ -5,6 +5,8 @@ require_once __DIR__ . '/../models/Eleve.php';
 require_once __DIR__ . '/../models/ModeleCarte.php';
 require_once __DIR__ . '/../models/Classe.php';
 require_once __DIR__ . '/../models/Etude.php';
+require_once __DIR__ . '/../models/ParamLycee.php';
+require_once __DIR__ . '/../models/AnneeAcademique.php';
 
 class CarteController {
 


### PR DESCRIPTION
Added missing `require_once` statements for `ParamLycee` and `AnneeAcademique` models in `CarteController.php` to ensure they are loaded before use. This follows the existing pattern of manual model requirements in the project.