### PR TITLE
feat: add user-facing identifiant_public for students and staff

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -109,6 +109,7 @@ CREATE TABLE `utilisateurs` (
     `date_embauche` DATE,
     `actif` BOOLEAN DEFAULT TRUE,
     `photo` TEXT,
+    `identifiant_public` VARCHAR(50) UNIQUE DEFAULT NULL,
     FOREIGN KEY (`lycee_id`) REFERENCES `param_lycee`(`id`) ON DELETE SET NULL,
     FOREIGN KEY (`role_id`) REFERENCES `roles`(`id_role`) ON DELETE SET NULL
 );
@@ -303,6 +304,7 @@ CREATE TABLE `eleves` (
     `email` VARCHAR(255) UNIQUE,
     `telephone` VARCHAR(50),
     `statut` ENUM('en_attente', 'en_attente_paiement', 'actif', 'transféré', 'radié', 'diplômé', 'abandonné') NOT NULL DEFAULT 'en_attente',
+    `identifiant_public` VARCHAR(50) UNIQUE DEFAULT NULL,
     FOREIGN KEY (`lycee_id`) REFERENCES `param_lycee`(`id`) ON DELETE CASCADE
 );
 

--- a/migrate.php
+++ b/migrate.php
@@ -76,6 +76,94 @@ try {
         FOREIGN KEY (`cree_par`) REFERENCES `utilisateurs`(`id_user`) ON DELETE SET NULL
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;");
 
+    // Add identifiant_public to eleves table
+    $db->exec("ALTER TABLE eleves ADD COLUMN IF NOT EXISTS identifiant_public VARCHAR(50) DEFAULT NULL;");
+    try {
+        $db->exec("ALTER TABLE eleves ADD UNIQUE (identifiant_public);");
+    } catch (Exception $e) {
+        // Safe if unique key already exists
+    }
+
+    // Add identifiant_public to utilisateurs table
+    $db->exec("ALTER TABLE utilisateurs ADD COLUMN IF NOT EXISTS identifiant_public VARCHAR(50) DEFAULT NULL;");
+    try {
+        $db->exec("ALTER TABLE utilisateurs ADD UNIQUE (identifiant_public);");
+    } catch (Exception $e) {
+        // Safe if unique key already exists
+    }
+
+    // Retroactive generation for existing students (eleves)
+    $stmt = $db->query("SELECT id_eleve, (SELECT date_activation FROM etudes WHERE eleve_id = id_eleve LIMIT 1) as date_activation FROM eleves WHERE identifiant_public IS NULL ORDER BY id_eleve ASC");
+    $eleves_without_id = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+    if (!empty($eleves_without_id)) {
+        $stmt_counter = $db->query("SELECT identifiant_public FROM eleves WHERE identifiant_public LIKE '%E' ORDER BY id_eleve DESC LIMIT 1");
+        $last_student_public_id = $stmt_counter->fetchColumn();
+        $student_counter = 1;
+        if ($last_student_public_id && preg_match('/-(\d+)E$/', $last_student_public_id, $matches)) {
+            $student_counter = (int)$matches[1] + 1;
+        }
+
+        $update_student_stmt = $db->prepare("UPDATE eleves SET identifiant_public = :identifiant_public WHERE id_eleve = :id_eleve");
+        foreach ($eleves_without_id as $e) {
+            $enrollDate = !empty($e['date_activation']) ? $e['date_activation'] : date('Y-m-d');
+            $dateStr = date('dmY', strtotime($enrollDate));
+            $paddedCounter = str_pad($student_counter, 4, '0', STR_PAD_LEFT);
+            $identifiant = $dateStr . '-' . $paddedCounter . 'E';
+
+            $update_student_stmt->execute([
+                'identifiant_public' => $identifiant,
+                'id_eleve' => $e['id_eleve']
+            ]);
+            $student_counter++;
+        }
+    }
+
+    // Retroactive generation for existing staff (utilisateurs)
+    $stmt = $db->query("SELECT id_user, role_id FROM utilisateurs WHERE identifiant_public IS NULL ORDER BY id_user ASC");
+    $users_without_id = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+    if (!empty($users_without_id)) {
+        $stmt_counter = $db->query("SELECT identifiant_public FROM utilisateurs WHERE identifiant_public IS NOT NULL ORDER BY id_user DESC LIMIT 1");
+        $last_user_public_id = $stmt_counter->fetchColumn();
+        $user_counter = 1;
+        if ($last_user_public_id && preg_match('/^(\d+)/', $last_user_public_id, $matches)) {
+            $user_counter = (int)$matches[1] + 1;
+        }
+
+        $update_user_stmt = $db->prepare("UPDATE utilisateurs SET identifiant_public = :identifiant_public WHERE id_user = :id_user");
+        foreach ($users_without_id as $u) {
+            $role_name = '';
+            if (!empty($u['role_id'])) {
+                $stmt_role = $db->prepare("SELECT nom_role FROM roles WHERE id_role = :id");
+                $stmt_role->execute(['id' => $u['role_id']]);
+                $role_name = $stmt_role->fetchColumn() ?: '';
+            }
+            $role_name = strtolower($role_name);
+
+            if (strpos($role_name, 'enseignant') !== false) {
+                $suffix = 'ENS';
+            } elseif (strpos($role_name, 'comptable') !== false) {
+                $suffix = 'COM';
+            } elseif (strpos($role_name, 'surveillant') !== false) {
+                $suffix = 'SUR';
+            } elseif (strpos($role_name, 'proviseur') !== false || strpos($role_name, 'censeur') !== false || strpos($role_name, 'directeur') !== false) {
+                $suffix = 'DIR';
+            } else {
+                $suffix = 'ADM';
+            }
+
+            $paddedCounter = str_pad($user_counter, 4, '0', STR_PAD_LEFT);
+            $identifiant = $paddedCounter . $suffix;
+
+            $update_user_stmt->execute([
+                'identifiant_public' => $identifiant,
+                'id_user' => $u['id_user']
+            ]);
+            $user_counter++;
+        }
+    }
+
     echo "Migration successful\n";
 } catch (Exception $e) {
     echo "Migration failed: " . $e->getMessage() . "\n";

--- a/src/controllers/MensualiteController.php
+++ b/src/controllers/MensualiteController.php
@@ -62,7 +62,7 @@ class MensualiteController {
 
         $db = Database::getInstance();
         $stmt = $db->prepare("
-            SELECT e.*, et.id_etude, et.status as etude_status
+            SELECT e.*, e.identifiant_public AS matricule, et.id_etude, et.status as etude_status
             FROM eleves e
             JOIN etudes et ON e.id_eleve = et.eleve_id
             WHERE et.classe_id = :classe_id

--- a/src/controllers/PaiementController.php
+++ b/src/controllers/PaiementController.php
@@ -385,7 +385,8 @@ class PaiementController {
                     'Espèces' as mode,
                     i.recu_numero,
                     u.nom as caissier_nom, u.prenom as caissier_prenom,
-                    e.id_eleve
+                    e.id_eleve,
+                    e.identifiant_public
                 FROM inscriptions i
                 JOIN eleves e ON i.eleve_id = e.id_eleve
                 JOIN classes c ON i.classe_id = c.id_classe
@@ -403,7 +404,8 @@ class PaiementController {
                     md.mode_paiement as mode,
                     md.recu_numero,
                     u.nom as caissier_nom, u.prenom as caissier_prenom,
-                    e.id_eleve
+                    e.id_eleve,
+                    e.identifiant_public
                 FROM mensualite_details md
                 JOIN mensualites m ON md.mensualite_id = m.id_mensualite
                 JOIN eleves e ON m.eleve_id = e.id_eleve
@@ -422,10 +424,11 @@ class PaiementController {
         ];
 
         if (!empty($search)) {
-            $sql .= " AND (nom LIKE :s1 OR prenom LIKE :s2 OR recu_numero LIKE :s3)";
+            $sql .= " AND (nom LIKE :s1 OR prenom LIKE :s2 OR recu_numero LIKE :s3 OR identifiant_public LIKE :s4)";
             $params['s1'] = "%$search%";
             $params['s2'] = "%$search%";
             $params['s3'] = "%$search%";
+            $params['s4'] = "%$search%";
         }
 
         $sql .= " ORDER BY date DESC";
@@ -457,7 +460,7 @@ class PaiementController {
                 recu_numero,
                 MAX(date) as date,
                 SUM(montant) as montant_total,
-                nom, prenom, id_eleve,
+                nom, prenom, id_eleve, identifiant_public,
                 GROUP_CONCAT(DISTINCT type SEPARATOR ', ') as types
             FROM (
                 SELECT
@@ -465,7 +468,8 @@ class PaiementController {
                     i.date_inscription as date,
                     i.montant_verse as montant,
                     e.nom, e.prenom, e.id_eleve,
-                    'Inscription' as type
+                    'Inscription' as type,
+                    e.identifiant_public
                 FROM inscriptions i
                 JOIN eleves e ON i.eleve_id = e.id_eleve
                 WHERE i.lycee_id = :l1
@@ -477,7 +481,8 @@ class PaiementController {
                     md.date_paiement as date,
                     md.montant,
                     e.nom, e.prenom, e.id_eleve,
-                    'Mensualité' as type
+                    'Mensualité' as type,
+                    e.identifiant_public
                 FROM mensualite_details md
                 JOIN mensualites m ON md.mensualite_id = m.id_mensualite
                 JOIN eleves e ON m.eleve_id = e.id_eleve
@@ -489,13 +494,14 @@ class PaiementController {
         $params = ['l1' => $lycee_id, 'l2' => $lycee_id];
 
         if (!empty($search)) {
-            $sql .= " AND (recu_numero LIKE :s1 OR nom LIKE :s2 OR prenom LIKE :s3)";
+            $sql .= " AND (recu_numero LIKE :s1 OR nom LIKE :s2 OR prenom LIKE :s3 OR identifiant_public LIKE :s4)";
             $params['s1'] = "%$search%";
             $params['s2'] = "%$search%";
             $params['s3'] = "%$search%";
+            $params['s4'] = "%$search%";
         }
 
-        $sql .= " GROUP BY recu_numero, id_eleve ORDER BY date DESC";
+        $sql .= " GROUP BY recu_numero, id_eleve, identifiant_public ORDER BY date DESC";
 
         $stmt = $db->prepare($sql);
         $stmt->execute($params);
@@ -698,7 +704,7 @@ class PaiementController {
 
         $db = Database::getInstance();
         $stmt = $db->prepare("
-            SELECT e.*, et.id_etude
+            SELECT e.*, e.identifiant_public AS matricule, et.id_etude
             FROM eleves e
             JOIN etudes et ON e.id_eleve = et.eleve_id
             WHERE et.classe_id = :classe_id

--- a/src/models/Eleve.php
+++ b/src/models/Eleve.php
@@ -11,7 +11,7 @@ class Eleve {
      */
     public static function findAll($filters = []) {
         $db = Database::getInstance();
-        $sql = "SELECT e.*, c.niveau, c.serie, c.numero, cy.nom_cycle, l.nom_lycee
+        $sql = "SELECT e.*, e.identifiant_public AS matricule, c.niveau, c.serie, c.numero, cy.nom_cycle, l.nom_lycee
                 FROM eleves e
                 LEFT JOIN etudes et ON e.id_eleve = et.eleve_id
                     AND et.annee_academique_id = (SELECT id FROM annees_academiques WHERE est_active = 1 LIMIT 1)
@@ -56,7 +56,7 @@ class Eleve {
 
     public static function findById($id) {
         $db = Database::getInstance();
-        $stmt = $db->prepare("SELECT * FROM eleves WHERE id_eleve = :id");
+        $stmt = $db->prepare("SELECT *, identifiant_public AS matricule FROM eleves WHERE id_eleve = :id");
         $stmt->execute(['id' => $id]);
         return $stmt->fetch(PDO::FETCH_ASSOC);
     }
@@ -66,6 +66,28 @@ class Eleve {
      * @param array $data
      * @return bool
      */
+    /**
+     * Génère un identifiant public unique pour l'élève.
+     * Format : DDMMYYYY-0001E
+     */
+    public static function generatePublicId() {
+        $db = Database::getInstance();
+
+        // Get the absolute last generated public ID ending in 'E' to compute the next counter
+        $stmt = $db->query("SELECT identifiant_public FROM eleves WHERE identifiant_public LIKE '%E' ORDER BY id_eleve DESC LIMIT 1");
+        $lastId = $stmt->fetchColumn();
+
+        $counter = 1;
+        if ($lastId && preg_match('/-(\d+)E$/', $lastId, $matches)) {
+            $counter = (int)$matches[1] + 1;
+        }
+
+        $dateStr = date('dmY');
+        $paddedCounter = str_pad($counter, 4, '0', STR_PAD_LEFT);
+
+        return $dateStr . '-' . $paddedCounter . 'E';
+    }
+
     public static function save($data) {
         if (empty($data['nom']) || empty($data['prenom']) || empty($data['lycee_id'])) {
             throw new InvalidArgumentException("Les informations de base (nom, prénom, lycée) sont obligatoires.");
@@ -74,7 +96,7 @@ class Eleve {
         $db = Database::getInstance();
         $isUpdate = !empty($data['id_eleve']);
 
-        $fields = ['lycee_id', 'nom', 'prenom', 'date_naissance', 'lieu_naissance', 'nationalite', 'sexe', 'quartier', 'tel_parent', 'nom_pere', 'nom_mere', 'profession_pere', 'profession_mere', 'email', 'telephone', 'statut'];
+        $fields = ['lycee_id', 'nom', 'prenom', 'date_naissance', 'lieu_naissance', 'nationalite', 'sexe', 'quartier', 'tel_parent', 'nom_pere', 'nom_mere', 'profession_pere', 'profession_mere', 'email', 'telephone', 'statut', 'identifiant_public'];
 
         if ($isUpdate) {
             $currentData = self::findById($data['id_eleve']);
@@ -93,6 +115,18 @@ class Eleve {
                 $params[$field] = $currentData[$field];
             } else {
                 $params[$field] = null;
+            }
+        }
+
+        if ($isUpdate) {
+            $params['identifiant_public'] = $currentData['identifiant_public'] ?? null;
+        } else {
+            if (empty($params['identifiant_public'])) {
+                if (!empty($data['matricule'])) {
+                    $params['identifiant_public'] = $data['matricule'];
+                } else {
+                    $params['identifiant_public'] = self::generatePublicId();
+                }
             }
         }
 
@@ -143,7 +177,7 @@ class Eleve {
      */
     public static function findAllArchived($lycee_id = null) {
         $db = Database::getInstance();
-        $sql = "SELECT * FROM eleves WHERE statut NOT IN ('actif', 'en_attente', 'en_attente_paiement')";
+        $sql = "SELECT *, identifiant_public AS matricule FROM eleves WHERE statut NOT IN ('actif', 'en_attente', 'en_attente_paiement')";
 
         $params = [];
         if ($lycee_id !== null) {
@@ -171,7 +205,7 @@ class Eleve {
         $db = Database::getInstance();
         $placeholders = implode(',', array_fill(0, count($class_ids), '?'));
 
-        $sql = "SELECT e.*, c.niveau
+        $sql = "SELECT e.*, e.identifiant_public AS matricule, c.niveau
                 FROM eleves e
                 JOIN etudes et ON e.id_eleve = et.eleve_id
                 JOIN classes c ON et.classe_id = c.id_classe
@@ -197,7 +231,7 @@ class Eleve {
 
     public static function findByClass($classe_id) {
         $db = Database::getInstance();
-        $sql = "SELECT e.*
+        $sql = "SELECT e.*, e.identifiant_public AS matricule
                 FROM eleves e
                 JOIN etudes et ON e.id_eleve = et.eleve_id
                 WHERE et.classe_id = :classe_id AND et.is_active = 1";
@@ -208,7 +242,7 @@ class Eleve {
 
     public static function findByStatus($status, $lycee_id = null) {
         $db = Database::getInstance();
-        $sql = "SELECT * FROM eleves WHERE statut = :statut";
+        $sql = "SELECT *, identifiant_public AS matricule FROM eleves WHERE statut = :statut";
         $params = ['statut' => $status];
         if ($lycee_id) {
             $sql .= " AND lycee_id = :lycee_id";
@@ -227,7 +261,7 @@ class Eleve {
      */
     public static function search($term, $lycee_id = null) {
         $db = Database::getInstance();
-        $sql = "SELECT * FROM eleves WHERE (nom LIKE :term OR prenom LIKE :term OR CAST(id_eleve AS CHAR) LIKE :term)";
+        $sql = "SELECT *, identifiant_public AS matricule FROM eleves WHERE (nom LIKE :term OR prenom LIKE :term OR CAST(id_eleve AS CHAR) LIKE :term OR identifiant_public LIKE :term)";
         $params = ['term' => '%' . $term . '%'];
 
         if ($lycee_id) {

--- a/src/models/User.php
+++ b/src/models/User.php
@@ -21,6 +21,7 @@ class User {
     public $date_embauche;
     public $actif;
     public $photo;
+    public $identifiant_public;
 
     public function __construct($data = []) {
         if (!empty($data)) {
@@ -41,6 +42,7 @@ class User {
             $this->date_embauche = $data['date_embauche'] ?? null;
             $this->actif = $data['actif'] ?? true;
             $this->photo = $data['photo'] ?? null;
+            $this->identifiant_public = $data['identifiant_public'] ?? null;
         }
     }
 
@@ -91,9 +93,64 @@ class User {
 
     // --- Full CRUD Methods ---
 
+    /**
+     * Génère un identifiant public unique pour le personnel.
+     * Format : [counter][SUFFIX]
+     */
+    public static function generatePublicId($role_id) {
+        $db = Database::getInstance();
+
+        // Find the suffix based on role
+        $suffix = self::getSuffixForRole($role_id);
+
+        // Find the last personnel's public ID to determine the next counter
+        $stmt = $db->query("SELECT identifiant_public FROM utilisateurs WHERE identifiant_public IS NOT NULL ORDER BY id_user DESC LIMIT 1");
+        $lastId = $stmt->fetchColumn();
+
+        $counter = 1;
+        if ($lastId && preg_match('/^(\d+)/', $lastId, $matches)) {
+            $counter = (int)$matches[1] + 1;
+        }
+
+        $paddedCounter = str_pad($counter, 4, '0', STR_PAD_LEFT);
+
+        return $paddedCounter . $suffix;
+    }
+
+    /**
+     * Détermine le suffixe de l'identifiant public en fonction du rôle.
+     */
+    public static function getSuffixForRole($role_id_or_name) {
+        $role_name = '';
+        if (is_numeric($role_id_or_name)) {
+            $db = Database::getInstance();
+            $stmt = $db->prepare("SELECT nom_role FROM roles WHERE id_role = :id");
+            $stmt->execute(['id' => $role_id_or_name]);
+            $role_name = $stmt->fetchColumn() ?: '';
+        } else {
+            $role_name = (string)$role_id_or_name;
+        }
+
+        $role_name = strtolower($role_name);
+
+        if (strpos($role_name, 'enseignant') !== false) {
+            return 'ENS';
+        } elseif (strpos($role_name, 'comptable') !== false) {
+            return 'COM';
+        } elseif (strpos($role_name, 'surveillant') !== false) {
+            return 'SUR';
+        } elseif (strpos($role_name, 'proviseur') !== false || strpos($role_name, 'censeur') !== false || strpos($role_name, 'directeur') !== false) {
+            return 'DIR';
+        } elseif (strpos($role_name, 'admin') !== false) {
+            return 'ADM';
+        } else {
+            return 'ADM'; // Default fallback
+        }
+    }
+
     public static function findAll($lycee_id = null) {
         $db = Database::getInstance();
-        $sql = "SELECT u.id_user, u.nom, u.prenom, u.actif, u.photo, r.nom_role
+        $sql = "SELECT u.id_user, u.nom, u.prenom, u.actif, u.photo, u.identifiant_public, r.nom_role
                 FROM utilisateurs u
                 LEFT JOIN roles r ON u.role_id = r.id_role";
         if ($lycee_id !== null) {
@@ -164,10 +221,10 @@ class User {
         } else {
             $sql = "INSERT INTO utilisateurs (
                         nom, prenom, sexe, date_naissance, lieu_naissance, adresse, telephone, email,
-                        mot_de_passe, fonction, role_id, lycee_id, contrat_id, date_embauche, actif, photo
+                        mot_de_passe, fonction, role_id, lycee_id, contrat_id, date_embauche, actif, photo, identifiant_public
                     ) VALUES (
                         :nom, :prenom, :sexe, :date_naissance, :lieu_naissance, :adresse, :telephone, :email,
-                        :mot_de_passe, :fonction, :role_id, :lycee_id, :contrat_id, :date_embauche, :actif, :photo
+                        :mot_de_passe, :fonction, :role_id, :lycee_id, :contrat_id, :date_embauche, :actif, :photo, :identifiant_public
                     )";
         }
 
@@ -209,6 +266,7 @@ class User {
                 'date_embauche' => empty($data['date_embauche']) ? null : $data['date_embauche'],
                 'actif' => $data['actif'] ?? 1,
                 'photo' => $data['photo'] ?? null,
+                'identifiant_public' => self::generatePublicId($data['role_id'])
             ];
         }
 
@@ -240,7 +298,7 @@ class User {
     public static function findAllByRoleName($role_name, $lycee_id) {
         $db = Database::getInstance();
         $stmt = $db->prepare("
-            SELECT u.id_user, u.nom, u.prenom FROM utilisateurs u
+            SELECT u.id_user, u.nom, u.prenom, u.identifiant_public FROM utilisateurs u
             JOIN roles r ON u.role_id = r.id_role
             WHERE r.nom_role = :role_name AND u.lycee_id = :lycee_id
             ORDER BY u.nom, u.prenom
@@ -280,7 +338,7 @@ class User {
 
         $db = Database::getInstance();
         $sql = "
-            SELECT u.id_user, CONCAT(u.prenom, ' ', u.nom) as full_name
+            SELECT u.id_user, u.identifiant_public, CONCAT(u.prenom, ' ', u.nom) as full_name
             FROM utilisateurs u
             JOIN roles r ON u.role_id = r.id_role
             WHERE u.lycee_id = :lycee_id

--- a/src/views/bulletins/blocs/_info_eleve.php
+++ b/src/views/bulletins/blocs/_info_eleve.php
@@ -1,4 +1,7 @@
 <div class="student-info mb-4">
+    <?php if (!empty($bulletin['eleve']['identifiant_public'])): ?>
+        <p><strong>Matricule :</strong> <?= htmlspecialchars($bulletin['eleve']['identifiant_public'] ?? '') ?></p>
+    <?php endif; ?>
     <p><strong>Nom & Prénom :</strong> <?= htmlspecialchars($bulletin['eleve']['prenom'] . ' ' . $bulletin['eleve']['nom']) ?></p>
     <p><strong>Date de Naissance :</strong> <?= htmlspecialchars($bulletin['eleve']['date_naissance']) ?></p>
     <p><strong>Classe :</strong> <?= htmlspecialchars($bulletin['eleve']['nom_classe']) ?></p>

--- a/src/views/carte/generer.php
+++ b/src/views/carte/generer.php
@@ -140,7 +140,7 @@
                         content = (elData.text || '{nom_complet}').replace('{nom_complet}', `${eleve.prenom} ${eleve.nom}`.toUpperCase());
                         break;
                     case 'matricule':
-                        content = (elData.text || '{matricule}').replace('{matricule}', `${eleve.id_eleve}`);
+                        content = (elData.text || '{matricule}').replace('{matricule}', `${eleve.identifiant_public || eleve.id_eleve}`);
                         break;
                     case 'classe':
                         const className = `${classe.niveau} ${classe.serie ? ' / ' + classe.serie : ''} ${classe.numero || ''}`.trim();

--- a/src/views/eleves/details.php
+++ b/src/views/eleves/details.php
@@ -59,6 +59,9 @@
                         <h5><?= _('Informations Personnelles') ?></h5>
                     </div>
                     <div class="card-body">
+                        <?php if (!empty($eleve['identifiant_public'])): ?>
+                            <p><strong><?= _('Identifiant Public / Matricule') ?>:</strong> <span class="badge bg-light-primary text-primary"><?= htmlspecialchars($eleve['identifiant_public'] ?? '') ?></span></p>
+                        <?php endif; ?>
                         <p><strong><?= _('Nom & Prénom') ?>:</strong> <?= htmlspecialchars($eleve['prenom'] . ' ' . $eleve['nom']) ?></p>
                         <p><strong><?= _('Date de Naissance') ?>:</strong> <?= htmlspecialchars($eleve['date_naissance']) ?></p>
                         <p><strong><?= _('Lieu de Naissance') ?>:</strong> <?= htmlspecialchars($eleve['lieu_naissance']) ?></p>

--- a/src/views/eleves/index.php
+++ b/src/views/eleves/index.php
@@ -116,7 +116,12 @@
                                                         <img src="/assets/img/placeholder-photo.png" alt="Avatar par défaut" class="img-thumbnail" style="width: 50px; height: 50px; object-fit: cover;">
                                                     <?php endif; ?>
                                                 </td>
-                                                <td><?= htmlspecialchars($eleve['prenom'] . ' ' . $eleve['nom']) ?></td>
+                                                <td>
+                                                    <?= htmlspecialchars($eleve['prenom'] . ' ' . $eleve['nom']) ?>
+                                                    <?php if (!empty($eleve['identifiant_public'])): ?>
+                                                        <br><small class="text-muted"><?= htmlspecialchars($eleve['identifiant_public'] ?? '') ?></small>
+                                                    <?php endif; ?>
+                                                </td>
                                                 <td><?= htmlspecialchars($eleve['nom_lycee']) ?></td>
                                                 <td>
                                                     <?php if (!empty($eleve['niveau'])): ?>

--- a/src/views/recus/inscription.php
+++ b/src/views/recus/inscription.php
@@ -78,6 +78,9 @@
             <div class="info-box">
                 <span class="info-label">Élève</span>
                 <span class="info-value"><?= htmlspecialchars($eleve['prenom'] . ' ' . $eleve['nom']) ?></span>
+                <?php if (!empty($eleve['identifiant_public'])): ?>
+                    <br><span class="info-label" style="margin-top: 5px;">Matricule: <?= htmlspecialchars($eleve['identifiant_public'] ?? '') ?></span>
+                <?php endif; ?>
             </div>
             <div class="info-box">
                 <span class="info-label">Année Académique</span>

--- a/src/views/recus/mensualite.php
+++ b/src/views/recus/mensualite.php
@@ -71,6 +71,9 @@
             <div class="info-box">
                 <span class="info-label">Élève</span>
                 <span class="info-value"><?= htmlspecialchars($eleve['prenom'] . ' ' . $eleve['nom']) ?></span>
+                <?php if (!empty($eleve['identifiant_public'])): ?>
+                    <br><span class="info-label" style="margin-top: 5px;">Matricule: <?= htmlspecialchars($eleve['identifiant_public'] ?? '') ?></span>
+                <?php endif; ?>
             </div>
             <div class="info-box">
                 <span class="info-label">Année Académique</span>

--- a/src/views/users/index.php
+++ b/src/views/users/index.php
@@ -72,7 +72,12 @@
                                                         <img src="/assets/img/placeholder-photo.png" alt="Avatar par défaut" class="img-thumbnail" style="width: 50px; height: 50px; object-fit: cover;">
                                                     <?php endif; ?>
                                                 </td>
-                                                <td><?= htmlspecialchars($user['prenom'] . ' ' . $user['nom']) ?></td>
+                                                <td>
+                                                    <?= htmlspecialchars($user['prenom'] . ' ' . $user['nom']) ?>
+                                                    <?php if (!empty($user['identifiant_public'])): ?>
+                                                        <br><small class="text-muted"><?= htmlspecialchars($user['identifiant_public'] ?? '') ?></small>
+                                                    <?php endif; ?>
+                                                </td>
                                                 <td><?= htmlspecialchars($user['nom_role'] ?? 'N/A') ?></td>
                                                 <td>
                                                     <?php if ($user['actif']): ?>

--- a/src/views/users/view.php
+++ b/src/views/users/view.php
@@ -53,6 +53,9 @@
 
                         <h5 class="border-bottom pb-2 mt-4 mb-3"><?= _('Informations Professionnelles') ?></h5>
                         <div class="row">
+                            <?php if (!empty($user['identifiant_public'])): ?>
+                                <div class="col-sm-6 mb-2"><strong><?= _('Identifiant Public') ?>:</strong> <span class="badge bg-light-primary text-primary"><?= htmlspecialchars($user['identifiant_public'] ?? '') ?></span></div>
+                            <?php endif; ?>
                             <div class="col-sm-6 mb-2"><strong><?= _('Rôle') ?>:</strong> <?= htmlspecialchars($role['nom_role'] ?? 'N/A') ?></div>
                             <div class="col-sm-6 mb-2"><strong><?= _('Type de Contrat') ?>:</strong> <?= htmlspecialchars($contrat['libelle'] ?? 'N/A') ?></div>
                             <div class="col-sm-6 mb-2"><strong><?= _('Date d\'embauche') ?>:</strong> <?= htmlspecialchars($user['date_embauche'] ?? 'N/A') ?></div>


### PR DESCRIPTION
- Added `identifiant_public` column to both `eleves` and `utilisateurs` tables.
- Implemented automatic generation in `migrate.php` for existing records.
- Added `generatePublicId` helpers in `Eleve` and `User` models to assign the public identifiers upon student enrollment or user creation.
- Made the public identifier permanent and non-modifiable.
- Enabled smart searches by `identifiant_public` in search bars and workflows.
- Displayed `identifiant_public` across all relevant templates, lists, and documents.
- Ensured perfect backward compatibility by mapping `identifiant_public AS matricule` in student models, leaving all internal technical keys and relationships untouched.