### PR TITLE
Fix PHP Fatal Error in financial control rendering and avoid referenc…

### DIFF
--- a/src/controllers/PaiementController.php
+++ b/src/controllers/PaiementController.php
@@ -613,6 +613,7 @@ class PaiementController {
                 $s['bulletin_impression'] = $state['bulletin_impression'];
             }
         }
+        unset($s);
 
         // 2. Compute Dashboard statistics
         $stats = [

--- a/src/views/bulletins/class_results.php
+++ b/src/views/bulletins/class_results.php
@@ -11,7 +11,7 @@ require_once __DIR__ . '/../layouts/sidebar_able.php';
                 <div class="row align-items-center">
                     <div class="col-md-12">
                         <div class="page-header-title">
-                            <h2 class="mb-0"><?= _('Class Results for:') ?> <?= htmlspecialchars(Classe::getFormattedName($classe['niveau'], $classe['serie'], $classe['numero'])) ?></h2>
+                            <h2 class="mb-0"><?= _('Class Results for:') ?> <?= htmlspecialchars(Classe::getFormattedName($classe)) ?></h2>
                         </div>
                     </div>
                 </div>

--- a/src/views/bulletins/index.php
+++ b/src/views/bulletins/index.php
@@ -35,7 +35,7 @@ require_once __DIR__ . '/../layouts/sidebar_able.php';
                                         <select name="classe_id" id="classe_id" class="form-select" required>
                                             <option value=""><?= _('-- Select a class --') ?></option>
                                             <?php foreach ($classes as $classe): ?>
-                                                <option value="<?= $classe['id_classe'] ?>"><?= htmlspecialchars(Classe::getFormattedName($classe['niveau'], $classe['serie'], $classe['numero'])) ?></option>
+                                                <option value="<?= $classe['id_classe'] ?>"><?= htmlspecialchars(Classe::getFormattedName($classe)) ?></option>
                                             <?php endforeach; ?>
                                         </select>
                                     </div>

--- a/src/views/paiements/controle.php
+++ b/src/views/paiements/controle.php
@@ -142,7 +142,7 @@ require_once __DIR__ . '/../layouts/sidebar_able.php';
                                                     <span class="d-block text-muted small">ID: #<?= $s['id_eleve'] ?></span>
                                                 </td>
                                                 <td>
-                                                    <span class="badge bg-light-secondary"><?= htmlspecialchars(Classe::getFormattedName($s['niveau'], $s['serie'], $s['numero'])) ?></span>
+                                                    <span class="badge bg-light-secondary"><?= htmlspecialchars(Classe::getFormattedName($s)) ?></span>
                                                 </td>
                                                 <td>
                                                     <?php if (!empty($s['type_avantage']) && $s['type_avantage'] !== 'Aucun'): ?>


### PR DESCRIPTION
…e leak

- Modified calls to Classe::getFormattedName() in src/views/paiements/controle.php, src/views/bulletins/class_results.php, and src/views/bulletins/index.php to pass the actual array variable as expected by the function, rather than three separate string parameters.
- Added unset($s) in PaiementController::controle() to prevent PHP reference leakage during sequential student list processing.