### PR TITLE
fix(payments): add validation and success alerts to payment views to …

### DIFF
--- a/src/views/paiements/inscription_pay.php
+++ b/src/views/paiements/inscription_pay.php
@@ -20,6 +20,29 @@
             </div>
         </div>
 
+        <!-- Alerts Display -->
+        <?php if (isset($_SESSION['success_message'])): ?>
+            <div class="alert alert-success alert-dismissible fade show shadow-sm" role="alert">
+                <div class="d-flex align-items-center">
+                    <i class="ph-duotone ph-check-circle me-2 fs-4"></i>
+                    <div><?= htmlspecialchars($_SESSION['success_message'] ?? '') ?></div>
+                </div>
+                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+            </div>
+            <?php unset($_SESSION['success_message']); ?>
+        <?php endif; ?>
+
+        <?php if (isset($_SESSION['error_message'])): ?>
+            <div class="alert alert-danger alert-dismissible fade show shadow-sm" role="alert">
+                <div class="d-flex align-items-center">
+                    <i class="ph-duotone ph-warning-circle me-2 fs-4"></i>
+                    <div><?= htmlspecialchars($_SESSION['error_message'] ?? '') ?></div>
+                </div>
+                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+            </div>
+            <?php unset($_SESSION['error_message']); ?>
+        <?php endif; ?>
+
         <form action="/paiements/process-payment/<?= $eleve['id_eleve'] ?>" method="POST">
             <div class="row">
                 <div class="col-lg-6">

--- a/src/views/paiements/pending.php
+++ b/src/views/paiements/pending.php
@@ -20,6 +20,29 @@
             </div>
         </div>
 
+        <!-- Alerts Display -->
+        <?php if (isset($_SESSION['success_message'])): ?>
+            <div class="alert alert-success alert-dismissible fade show shadow-sm" role="alert">
+                <div class="d-flex align-items-center">
+                    <i class="ph-duotone ph-check-circle me-2 fs-4"></i>
+                    <div><?= htmlspecialchars($_SESSION['success_message'] ?? '') ?></div>
+                </div>
+                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+            </div>
+            <?php unset($_SESSION['success_message']); ?>
+        <?php endif; ?>
+
+        <?php if (isset($_SESSION['error_message'])): ?>
+            <div class="alert alert-danger alert-dismissible fade show shadow-sm" role="alert">
+                <div class="d-flex align-items-center">
+                    <i class="ph-duotone ph-warning-circle me-2 fs-4"></i>
+                    <div><?= htmlspecialchars($_SESSION['error_message'] ?? '') ?></div>
+                </div>
+                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+            </div>
+            <?php unset($_SESSION['error_message']); ?>
+        <?php endif; ?>
+
         <div class="row">
             <div class="col-md-12">
                 <div class="card">

--- a/src/views/paiements/recus.php
+++ b/src/views/paiements/recus.php
@@ -17,6 +17,29 @@
             </div>
         </div>
 
+        <!-- Alerts Display -->
+        <?php if (isset($_SESSION['success_message'])): ?>
+            <div class="alert alert-success alert-dismissible fade show shadow-sm" role="alert">
+                <div class="d-flex align-items-center">
+                    <i class="ph-duotone ph-check-circle me-2 fs-4"></i>
+                    <div><?= htmlspecialchars($_SESSION['success_message'] ?? '') ?></div>
+                </div>
+                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+            </div>
+            <?php unset($_SESSION['success_message']); ?>
+        <?php endif; ?>
+
+        <?php if (isset($_SESSION['error_message'])): ?>
+            <div class="alert alert-danger alert-dismissible fade show shadow-sm" role="alert">
+                <div class="d-flex align-items-center">
+                    <i class="ph-duotone ph-warning-circle me-2 fs-4"></i>
+                    <div><?= htmlspecialchars($_SESSION['error_message'] ?? '') ?></div>
+                </div>
+                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+            </div>
+            <?php unset($_SESSION['error_message']); ?>
+        <?php endif; ?>
+
         <div class="row">
             <div class="col-12">
                 <div class="card">

--- a/src/views/paiements/regler.php
+++ b/src/views/paiements/regler.php
@@ -23,6 +23,29 @@
         </div>
         <!-- [ breadcrumb ] end -->
 
+        <!-- Alerts Display -->
+        <?php if (isset($_SESSION['success_message'])): ?>
+            <div class="alert alert-success alert-dismissible fade show shadow-sm" role="alert">
+                <div class="d-flex align-items-center">
+                    <i class="ph-duotone ph-check-circle me-2 fs-4"></i>
+                    <div><?= htmlspecialchars($_SESSION['success_message'] ?? '') ?></div>
+                </div>
+                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+            </div>
+            <?php unset($_SESSION['success_message']); ?>
+        <?php endif; ?>
+
+        <?php if (isset($_SESSION['error_message'])): ?>
+            <div class="alert alert-danger alert-dismissible fade show shadow-sm" role="alert">
+                <div class="d-flex align-items-center">
+                    <i class="ph-duotone ph-warning-circle me-2 fs-4"></i>
+                    <div><?= htmlspecialchars($_SESSION['error_message'] ?? '') ?></div>
+                </div>
+                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+            </div>
+            <?php unset($_SESSION['error_message']); ?>
+        <?php endif; ?>
+
         <!-- [ Main Content ] start -->
         <div class="row">
             <!-- Student Header -->

--- a/src/views/paiements/show.php
+++ b/src/views/paiements/show.php
@@ -22,6 +22,29 @@
         </div>
         <!-- [ breadcrumb ] end -->
 
+        <!-- Alerts Display -->
+        <?php if (isset($_SESSION['success_message'])): ?>
+            <div class="alert alert-success alert-dismissible fade show shadow-sm" role="alert">
+                <div class="d-flex align-items-center">
+                    <i class="ph-duotone ph-check-circle me-2 fs-4"></i>
+                    <div><?= htmlspecialchars($_SESSION['success_message'] ?? '') ?></div>
+                </div>
+                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+            </div>
+            <?php unset($_SESSION['success_message']); ?>
+        <?php endif; ?>
+
+        <?php if (isset($_SESSION['error_message'])): ?>
+            <div class="alert alert-danger alert-dismissible fade show shadow-sm" role="alert">
+                <div class="d-flex align-items-center">
+                    <i class="ph-duotone ph-warning-circle me-2 fs-4"></i>
+                    <div><?= htmlspecialchars($_SESSION['error_message'] ?? '') ?></div>
+                </div>
+                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+            </div>
+            <?php unset($_SESSION['error_message']); ?>
+        <?php endif; ?>
+
         <!-- [ Main Content ] start -->
         <div class="row">
             <!-- Student Info Summary -->


### PR DESCRIPTION
…prevent silent failures

Display $_SESSION['error_message'] and $_SESSION['success_message'] in the payment views (show, regler, pending, inscription_pay, and recus) using Bootstrap alerts. This prevents silent rollbacks or validations from leaving the user without feedback.