### PR TITLE
fix(payments): fix SQLSTATE[HY093] parameter count bug and capture fu…

### DIFF
--- a/src/controllers/PaiementController.php
+++ b/src/controllers/PaiementController.php
@@ -1175,7 +1175,9 @@ class PaiementController {
 
         } catch (Throwable $e) {
             if (isset($db) && $db->inTransaction()) $db->rollBack();
-            $_SESSION['error_message'] = "Erreur lors de l'encaissement : " . $e->getMessage();
+            $_SESSION['error_message'] = "Erreur lors de l'encaissement : " . $e->getMessage() .
+                                         " | Fichier: " . $e->getFile() . " (Ligne " . $e->getLine() . ")" .
+                                         " | Trace: " . substr($e->getTraceAsString(), 0, 500) . "...";
         }
 
         header('Location: /paiements/show/' . $eleveId);
@@ -1331,7 +1333,9 @@ class PaiementController {
 
         } catch (Throwable $e) {
             if (isset($db) && $db->inTransaction()) $db->rollBack();
-            $_SESSION['error_message'] = "Erreur lors de l'annulation : " . $e->getMessage();
+            $_SESSION['error_message'] = "Erreur lors de l'annulation : " . $e->getMessage() .
+                                         " | Fichier: " . $e->getFile() . " (Ligne " . $e->getLine() . ")" .
+                                         " | Trace: " . substr($e->getTraceAsString(), 0, 500) . "...";
         }
 
         header('Location: /paiements/recus');
@@ -1506,7 +1510,9 @@ class PaiementController {
 
         } catch (Throwable $e) {
             if (isset($db) && $db->inTransaction()) $db->rollBack();
-            $_SESSION['error_message'] = "Erreur lors du remboursement : " . $e->getMessage();
+            $_SESSION['error_message'] = "Erreur lors du remboursement : " . $e->getMessage() .
+                                         " | Fichier: " . $e->getFile() . " (Ligne " . $e->getLine() . ")" .
+                                         " | Trace: " . substr($e->getTraceAsString(), 0, 500) . "...";
         }
 
         header('Location: /paiements/show/' . $eleveId);


### PR DESCRIPTION
…ll error traces in session

- Completely eliminate the UNION-based subquery inside Receipt Unique validation of `processPayment()` to resolve `SQLSTATE[HY093]: Invalid parameter number` under prepared statement configurations where `PDO::ATTR_EMULATE_PREPARES` is false.
- Simplified Receipt Unique check into two separate simple, direct queries on `inscriptions` and `mensualite_details`.
- Make double payment alert query parameters unique to avoid driver-level placeholder collisions.
- Render $_SESSION['error_message'] and $_SESSION['success_message'] in payment workflow views.
- Capture full Throwable details (Message, File Name, Line Number, and Stack Trace) inside catch blocks to make debugging instant and transparent.