### PR TITLE
feat: add modular digital signatures and official stamps

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -882,4 +882,18 @@ CREATE TABLE `etats_financiers_eleves` (
     FOREIGN KEY (`eleve_id`) REFERENCES `eleves`(`id_eleve`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
+CREATE TABLE `parametres_utilisateurs` (
+    `id` INT AUTO_INCREMENT PRIMARY KEY,
+    `user_id` INT NOT NULL UNIQUE,
+    `lycee_id` INT DEFAULT NULL,
+    `signature` TEXT DEFAULT NULL,
+    `cachet` TEXT DEFAULT NULL,
+    `langue_preferee` VARCHAR(10) DEFAULT 'fr_FR',
+    `theme_prefere` VARCHAR(50) DEFAULT 'light',
+    `notifications_actives` TINYINT(1) DEFAULT 1,
+    `date_modification` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    FOREIGN KEY (`user_id`) REFERENCES `utilisateurs`(`id_user`) ON DELETE CASCADE,
+    FOREIGN KEY (`lycee_id`) REFERENCES `param_lycee`(`id`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
 SET FOREIGN_KEY_CHECKS = 1;

--- a/migrate.php
+++ b/migrate.php
@@ -190,6 +190,21 @@ try {
         }
     }
 
+    // Create parametres_utilisateurs table
+    $db->exec("CREATE TABLE IF NOT EXISTS parametres_utilisateurs (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        user_id INT NOT NULL UNIQUE,
+        lycee_id INT DEFAULT NULL,
+        signature TEXT DEFAULT NULL,
+        cachet TEXT DEFAULT NULL,
+        langue_preferee VARCHAR(10) DEFAULT 'fr_FR',
+        theme_prefere VARCHAR(50) DEFAULT 'light',
+        notifications_actives TINYINT(1) DEFAULT 1,
+        date_modification TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+        FOREIGN KEY (user_id) REFERENCES utilisateurs(id_user) ON DELETE CASCADE,
+        FOREIGN KEY (lycee_id) REFERENCES param_lycee(id) ON DELETE SET NULL
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;");
+
     echo "Migration successful\n";
 } catch (Exception $e) {
     echo "Migration failed: " . $e->getMessage() . "\n";

--- a/public/index.php
+++ b/public/index.php
@@ -159,6 +159,7 @@ $router->register('/users/update', 'UserController', 'update');
 $router->register('/users/destroy', 'UserController', 'destroy');
 $router->register('/profile', 'UserController', 'profile');
 $router->register('/profile/update-password', 'UserController', 'updatePassword');
+$router->register('/profile/update-settings', 'UserController', 'updateSettings');
 
 // Eleves CRUD
 $router->register('/eleves', 'EleveController', 'index');

--- a/src/controllers/UserController.php
+++ b/src/controllers/UserController.php
@@ -5,6 +5,7 @@ require_once __DIR__ . '/../models/Lycee.php';
 require_once __DIR__ . '/../models/Role.php';
 require_once __DIR__ . '/../models/TypeContrat.php';
 require_once __DIR__ . '/../core/Validator.php';
+require_once __DIR__ . '/../models/ParametreUtilisateur.php';
 
 class UserController {
 
@@ -264,8 +265,11 @@ class UserController {
             exit();
         }
 
+        $parametres = ParametreUtilisateur::findByUserId($user_id);
+
         $data = [
             'user' => $user,
+            'parametres' => $parametres,
             'title' => _('Mon Profil')
         ];
 
@@ -298,6 +302,123 @@ class UserController {
                 $_SESSION['success_message'] = 'Mot de passe mis à jour avec succès.';
             } else {
                 $_SESSION['error_message'] = 'Erreur lors de la mise à jour du mot de passe.';
+            }
+
+            header('Location: /profile');
+            exit();
+        }
+    }
+
+    public function updateSettings() {
+        if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+            $user_id = Auth::get('id_user');
+            $user = User::findById($user_id);
+            if (!$user) {
+                $_SESSION['error_message'] = 'Utilisateur non trouvé.';
+                header('Location: /profile');
+                exit();
+            }
+
+            $parametres = ParametreUtilisateur::findByUserId($user_id);
+            $parametres->lycee_id = $user['lycee_id'] ?? null;
+            $parametres->langue_preferee = $_POST['langue_preferee'] ?? 'fr_FR';
+            $parametres->theme_prefere = $_POST['theme_prefere'] ?? 'light';
+            $parametres->notifications_actives = isset($_POST['notifications_actives']) ? 1 : 0;
+
+            // Handle standard file uploads
+            // 1. Signature file upload
+            if (isset($_FILES['signature_file']) && $_FILES['signature_file']['error'] === UPLOAD_ERR_OK) {
+                $uploadDir = UPLOAD_BASE_DIR . '/signatures/';
+                if (!is_dir($uploadDir)) {
+                    mkdir($uploadDir, 0777, true);
+                }
+                @chmod($uploadDir, 0777);
+
+                $allowedTypes = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
+                $detectedType = mime_content_type($_FILES['signature_file']['tmp_name']);
+
+                if (in_array($detectedType, $allowedTypes)) {
+                    $extension = pathinfo($_FILES['signature_file']['name'], PATHINFO_EXTENSION);
+                    $fileName = 'signature_' . $user_id . '_' . time() . '.' . $extension;
+                    $targetFilePath = $uploadDir . $fileName;
+
+                    if (move_uploaded_file($_FILES['signature_file']['tmp_name'], $targetFilePath)) {
+                        if (!empty($parametres->signature)) {
+                            $oldPath = __DIR__ . '/../../public' . $parametres->signature;
+                            if (file_exists($oldPath)) {
+                                @unlink($oldPath);
+                            }
+                        }
+                        $parametres->signature = UPLOAD_PUBLIC_PATH . '/signatures/' . $fileName;
+                    }
+                }
+            }
+            // 2. Canvas Signature (Base64)
+            elseif (!empty($_POST['signature_base64'])) {
+                $base64 = $_POST['signature_base64'];
+                if (preg_match('/^data:image\/(\w+);base64,/', $base64, $type)) {
+                    $imgData = substr($base64, strpos($base64, ',') + 1);
+                    $imgData = base64_decode($imgData);
+
+                    if ($imgData !== false) {
+                        $uploadDir = UPLOAD_BASE_DIR . '/signatures/';
+                        if (!is_dir($uploadDir)) {
+                            mkdir($uploadDir, 0777, true);
+                        }
+                        @chmod($uploadDir, 0777);
+
+                        $fileName = 'signature_' . $user_id . '_' . time() . '.png';
+                        $targetFilePath = $uploadDir . $fileName;
+
+                        if (file_put_contents($targetFilePath, $imgData)) {
+                            if (!empty($parametres->signature)) {
+                                $oldPath = __DIR__ . '/../../public' . $parametres->signature;
+                                if (file_exists($oldPath)) {
+                                    @unlink($oldPath);
+                                }
+                            }
+                            $parametres->signature = UPLOAD_PUBLIC_PATH . '/signatures/' . $fileName;
+                        }
+                    }
+                }
+            }
+
+            // 3. Cachet file upload
+            if (isset($_FILES['cachet_file']) && $_FILES['cachet_file']['error'] === UPLOAD_ERR_OK) {
+                $uploadDir = UPLOAD_BASE_DIR . '/tampons/';
+                if (!is_dir($uploadDir)) {
+                    mkdir($uploadDir, 0777, true);
+                }
+                @chmod($uploadDir, 0777);
+
+                $allowedTypes = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
+                $detectedType = mime_content_type($_FILES['cachet_file']['tmp_name']);
+
+                if (in_array($detectedType, $allowedTypes)) {
+                    $extension = pathinfo($_FILES['cachet_file']['name'], PATHINFO_EXTENSION);
+                    $fileName = 'cachet_' . $user_id . '_' . time() . '.' . $extension;
+                    $targetFilePath = $uploadDir . $fileName;
+
+                    if (move_uploaded_file($_FILES['cachet_file']['tmp_name'], $targetFilePath)) {
+                        if (!empty($parametres->cachet)) {
+                            $oldPath = __DIR__ . '/../../public' . $parametres->cachet;
+                            if (file_exists($oldPath)) {
+                                @unlink($oldPath);
+                            }
+                        }
+                        $parametres->cachet = UPLOAD_PUBLIC_PATH . '/tampons/' . $fileName;
+                    }
+                }
+            }
+
+            // Save settings
+            if ($parametres->save()) {
+                $_SESSION['success_message'] = 'Paramètres et signatures enregistrés avec succès.';
+
+                // Update active locale session dynamically for the current user!
+                $_SESSION['locale'] = $parametres->langue_preferee;
+            } else {
+                $_SESSION['error_message'] = 'Erreur lors de l\'enregistrement des paramètres.';
             }
 
             header('Location: /profile');

--- a/src/models/ParametreUtilisateur.php
+++ b/src/models/ParametreUtilisateur.php
@@ -1,0 +1,108 @@
+<?php
+
+require_once __DIR__ . '/../config/database.php';
+
+class ParametreUtilisateur {
+    public $id;
+    public $user_id;
+    public $lycee_id;
+    public $signature;
+    public $cachet;
+    public $langue_preferee;
+    public $theme_prefere;
+    public $notifications_actives;
+    public $date_modification;
+
+    public function __construct($data = []) {
+        if (!empty($data)) {
+            $this->id = $data['id'] ?? null;
+            $this->user_id = $data['user_id'] ?? null;
+            $this->lycee_id = $data['lycee_id'] ?? null;
+            $this->signature = $data['signature'] ?? null;
+            $this->cachet = $data['cachet'] ?? null;
+            $this->langue_preferee = $data['langue_preferee'] ?? 'fr_FR';
+            $this->theme_prefere = $data['theme_prefere'] ?? 'light';
+            $this->notifications_actives = isset($data['notifications_actives']) ? (bool)$data['notifications_actives'] : true;
+            $this->date_modification = $data['date_modification'] ?? null;
+        }
+    }
+
+    /**
+     * Finds settings for a user. If none exist in the database, returns a new instance with default values.
+     *
+     * @param int $user_id
+     * @return ParametreUtilisateur
+     */
+    public static function findByUserId($user_id) {
+        try {
+            $db = Database::getInstance();
+            $stmt = $db->prepare("SELECT * FROM parametres_utilisateurs WHERE user_id = :user_id LIMIT 1");
+            $stmt->execute(['user_id' => $user_id]);
+            $data = $stmt->fetch(PDO::FETCH_ASSOC);
+
+            if ($data) {
+                return new self($data);
+            }
+        } catch (PDOException $e) {
+            error_log("Error in ParametreUtilisateur::findByUserId: " . $e->getMessage());
+        }
+
+        // Return default settings for user if none exist yet
+        return new self([
+            'user_id' => $user_id,
+            'langue_preferee' => 'fr_FR',
+            'theme_prefere' => 'light',
+            'notifications_actives' => true
+        ]);
+    }
+
+    /**
+     * Saves or updates the user settings (UPSERT).
+     *
+     * @return bool
+     */
+    public function save() {
+        try {
+            $db = Database::getInstance();
+
+            // Check if record already exists to handle both MySQL (ON DUPLICATE KEY UPDATE) and SQLite compatibility
+            $stmt_check = $db->prepare("SELECT id FROM parametres_utilisateurs WHERE user_id = :user_id");
+            $stmt_check->execute(['user_id' => $this->user_id]);
+            $exists = $stmt_check->fetchColumn();
+
+            if ($exists) {
+                // UPDATE
+                $sql = "UPDATE parametres_utilisateurs SET
+                            lycee_id = :lycee_id,
+                            signature = :signature,
+                            cachet = :cachet,
+                            langue_preferee = :langue_preferee,
+                            theme_prefere = :theme_prefere,
+                            notifications_actives = :notifications_actives
+                        WHERE user_id = :user_id";
+            } else {
+                // INSERT
+                $sql = "INSERT INTO parametres_utilisateurs
+                            (user_id, lycee_id, signature, cachet, langue_preferee, theme_prefere, notifications_actives)
+                        VALUES
+                            (:user_id, :lycee_id, :signature, :cachet, :langue_preferee, :theme_prefere, :notifications_actives)";
+            }
+
+            $stmt = $db->prepare($sql);
+            $params = [
+                'user_id' => $this->user_id,
+                'lycee_id' => $this->lycee_id,
+                'signature' => $this->signature,
+                'cachet' => $this->cachet,
+                'langue_preferee' => $this->langue_preferee ?: 'fr_FR',
+                'theme_prefere' => $this->theme_prefere ?: 'light',
+                'notifications_actives' => $this->notifications_actives ? 1 : 0
+            ];
+
+            return $stmt->execute($params);
+        } catch (PDOException $e) {
+            error_log("Error in ParametreUtilisateur::save: " . $e->getMessage());
+            return false;
+        }
+    }
+}

--- a/src/views/bulletins/blocs/_resume_moyennes.php
+++ b/src/views/bulletins/blocs/_resume_moyennes.php
@@ -38,6 +38,25 @@
                         <p><strong>Statut :</strong> <span class="badge badge-info"><?= ucfirst(htmlspecialchars($bulletin['bulletin_record']['statut'] ?? 'Provisoire')) ?></span></p>
                     <?php endif; ?>
                     <p class="mt-3"><strong>Le Chef d'établissement</strong></p>
+                    <?php
+                    require_once __DIR__ . '/../../../models/User.php';
+                    require_once __DIR__ . '/../../../models/ParametreUtilisateur.php';
+
+                    // Find director or proviseur
+                    $dirUser = User::findOneByRoleName('proviseur') ?: User::findOneByRoleName('directeur');
+                    $dirSettings = null;
+                    if ($dirUser) {
+                        $dirSettings = ParametreUtilisateur::findByUserId($dirUser['id_user']);
+                    }
+                    ?>
+                    <div style="height: 65px; display: flex; align-items: center; justify-content: start; position: relative; margin-top: 5px; margin-bottom: 5px;">
+                        <?php if ($dirSettings && !empty($dirSettings->signature)): ?>
+                            <img src="<?= htmlspecialchars($dirSettings->signature) ?>" alt="Signature Directeur" style="max-height: 55px; position: absolute; z-index: 2; left: 20px;">
+                        <?php endif; ?>
+                        <?php if ($dirSettings && !empty($dirSettings->cachet)): ?>
+                            <img src="<?= htmlspecialchars($dirSettings->cachet) ?>" alt="Cachet Directeur" style="max-height: 60px; opacity: 0.85; position: absolute; z-index: 1; left: 10px;">
+                        <?php endif; ?>
+                    </div>
                 </div>
             </div>
         </div>

--- a/src/views/recus/inscription.php
+++ b/src/views/recus/inscription.php
@@ -151,9 +151,24 @@
                 <p>Le Parent / L'Élève</p>
                 <div class="signature-line">Signature</div>
             </div>
-            <div class="signature-box">
+            <?php
+            require_once __DIR__ . '/../../models/ParametreUtilisateur.php';
+            $caissierSettings = null;
+            if (!empty($caissier['id_user'])) {
+                $caissierSettings = ParametreUtilisateur::findByUserId($caissier['id_user']);
+            }
+            ?>
+            <div class="signature-box" style="position: relative;">
                 <p>Le Caissier / Comptable</p>
-                <div class="signature-line">
+                <div style="height: 60px; display: flex; align-items: center; justify-content: center; position: relative;">
+                    <?php if ($caissierSettings && !empty($caissierSettings->signature)): ?>
+                        <img src="<?= htmlspecialchars($caissierSettings->signature) ?>" alt="Signature" style="max-height: 50px; position: absolute; z-index: 2;">
+                    <?php endif; ?>
+                    <?php if ($caissierSettings && !empty($caissierSettings->cachet)): ?>
+                        <img src="<?= htmlspecialchars($caissierSettings->cachet) ?>" alt="Cachet" style="max-height: 55px; opacity: 0.85; position: absolute; z-index: 1;">
+                    <?php endif; ?>
+                </div>
+                <div class="signature-line" style="margin-top: 5px;">
                     <?= htmlspecialchars(($caissier['prenom'] ?? '') . ' ' . ($caissier['nom'] ?? '')) ?>
                 </div>
                 <p style="font-size: 10px; margin-top: 5px;">Validé informatiquement</p>

--- a/src/views/recus/mensualite.php
+++ b/src/views/recus/mensualite.php
@@ -146,9 +146,24 @@
                 <p>Le Parent / L'Élève</p>
                 <div class="signature-line">Signature</div>
             </div>
-            <div class="signature-box">
+            <?php
+            require_once __DIR__ . '/../../models/ParametreUtilisateur.php';
+            $caissierSettings = null;
+            if (!empty($caissier['id_user'])) {
+                $caissierSettings = ParametreUtilisateur::findByUserId($caissier['id_user']);
+            }
+            ?>
+            <div class="signature-box" style="position: relative;">
                 <p>Le Caissier / Comptable</p>
-                <div class="signature-line">
+                <div style="height: 60px; display: flex; align-items: center; justify-content: center; position: relative;">
+                    <?php if ($caissierSettings && !empty($caissierSettings->signature)): ?>
+                        <img src="<?= htmlspecialchars($caissierSettings->signature) ?>" alt="Signature" style="max-height: 50px; position: absolute; z-index: 2;">
+                    <?php endif; ?>
+                    <?php if ($caissierSettings && !empty($caissierSettings->cachet)): ?>
+                        <img src="<?= htmlspecialchars($caissierSettings->cachet) ?>" alt="Cachet" style="max-height: 55px; opacity: 0.85; position: absolute; z-index: 1;">
+                    <?php endif; ?>
+                </div>
+                <div class="signature-line" style="margin-top: 5px;">
                     <?= htmlspecialchars(($caissier['prenom'] ?? '') . ' ' . ($caissier['nom'] ?? '')) ?>
                 </div>
                 <p style="font-size: 10px; margin-top: 5px;">Validé informatiquement</p>

--- a/src/views/users/profile.php
+++ b/src/views/users/profile.php
@@ -30,9 +30,101 @@
                 </div>
             </div>
             <div class="col-lg-8">
+                <?php if (isset($_SESSION['success_message'])): ?>
+                    <div class="alert alert-success alert-dismissible fade show" role="alert">
+                        <?= htmlspecialchars($_SESSION['success_message']) ?>
+                        <?php unset($_SESSION['success_message']); ?>
+                    </div>
+                <?php endif; ?>
+                <?php if (isset($_SESSION['error_message'])): ?>
+                    <div class="alert alert-danger alert-dismissible fade show" role="alert">
+                        <?= htmlspecialchars($_SESSION['error_message']) ?>
+                        <?php unset($_SESSION['error_message']); ?>
+                    </div>
+                <?php endif; ?>
+
+                <!-- Preferences and Signatures -->
+                <div class="card mb-4">
+                    <div class="card-header">
+                        <h5><i class="ph-duotone ph-gear me-2 text-primary"></i><?= _('Préférences & Signatures Numériques') ?></h5>
+                    </div>
+                    <div class="card-body">
+                        <form action="/profile/update-settings" method="POST" enctype="multipart/form-data">
+                            <div class="row g-3">
+                                <!-- Language selection -->
+                                <div class="col-md-6 mb-3">
+                                    <label for="langue_preferee" class="form-label font-weight-bold"><?= _('Langue préférée') ?></label>
+                                    <select class="form-select" id="langue_preferee" name="langue_preferee">
+                                        <option value="fr_FR" <?= (($parametres->langue_preferee ?? '') === 'fr_FR') ? 'selected' : '' ?>>Français (fr_FR)</option>
+                                        <option value="en_US" <?= (($parametres->langue_preferee ?? '') === 'en_US') ? 'selected' : '' ?>>English (en_US)</option>
+                                        <option value="ar" <?= (($parametres->langue_preferee ?? '') === 'ar') ? 'selected' : '' ?>>العربية (ar)</option>
+                                    </select>
+                                </div>
+
+                                <!-- Theme selection -->
+                                <div class="col-md-6 mb-3">
+                                    <label for="theme_prefere" class="form-label font-weight-bold"><?= _('Thème d\'affichage') ?></label>
+                                    <select class="form-select" id="theme_prefere" name="theme_prefere">
+                                        <option value="light" <?= (($parametres->theme_prefere ?? '') === 'light') ? 'selected' : '' ?>><?= _('Clair') ?></option>
+                                        <option value="dark" <?= (($parametres->theme_prefere ?? '') === 'dark') ? 'selected' : '' ?>><?= _('Sombre') ?></option>
+                                    </select>
+                                </div>
+                            </div>
+
+                            <div class="row">
+                                <!-- User Signature upload & preview -->
+                                <div class="col-md-6 mb-4">
+                                    <label class="form-label font-weight-bold d-block"><?= _('Signature Numérique (PNG transparent)') ?></label>
+                                    <?php if (!empty($parametres->signature)): ?>
+                                        <div class="mb-2 p-2 border rounded bg-light text-center">
+                                            <img src="<?= htmlspecialchars($parametres->signature) ?>" alt="Signature Actuelle" style="max-height: 80px; object-fit: contain;">
+                                            <p class="small text-muted m-0 mt-1"><?= _('Signature active') ?></p>
+                                        </div>
+                                    <?php endif; ?>
+                                    <input type="file" class="form-control mb-2" name="signature_file" accept="image/png, image/jpeg, image/jpg">
+                                    <span class="text-muted small"><?= _('Ou dessinez directement ci-dessous :') ?></span>
+
+                                    <!-- Canvas Signature Pad -->
+                                    <div class="mt-2">
+                                        <canvas id="signature-pad" class="border rounded bg-white w-100" style="height: 150px; cursor: crosshair; touch-action: none;"></canvas>
+                                        <div class="d-flex justify-content-between mt-1">
+                                            <button type="button" id="clear-signature" class="btn btn-sm btn-outline-danger"><?= _('Effacer le dessin') ?></button>
+                                            <span class="small text-primary"><i class="ph-duotone ph-hand-pointing"></i> <?= _('Signez ici') ?></span>
+                                        </div>
+                                        <input type="hidden" id="signature-base64" name="signature_base64">
+                                    </div>
+                                </div>
+
+                                <!-- User Cachet upload & preview -->
+                                <div class="col-md-6 mb-4">
+                                    <label class="form-label font-weight-bold d-block"><?= _('Cachet Nominatif / Tampon officiel (PNG transparent)') ?></label>
+                                    <?php if (!empty($parametres->cachet)): ?>
+                                        <div class="mb-2 p-2 border rounded bg-light text-center">
+                                            <img src="<?= htmlspecialchars($parametres->cachet) ?>" alt="Cachet Actuel" style="max-height: 80px; object-fit: contain;">
+                                            <p class="small text-muted m-0 mt-1"><?= _('Cachet actif') ?></p>
+                                        </div>
+                                    <?php endif; ?>
+                                    <input type="file" class="form-control mb-2" name="cachet_file" accept="image/png, image/jpeg, image/jpg">
+                                    <div class="form-text text-muted small"><?= _('Téléversez une image détourée (.png) de votre cachet officiel.') ?></div>
+                                </div>
+                            </div>
+
+                            <div class="form-check mb-4">
+                                <input class="form-check-input" type="checkbox" id="notifications_actives" name="notifications_actives" value="1" <?= ($parametres->notifications_actives) ? 'checked' : '' ?>>
+                                <label class="form-check-label font-weight-bold" for="notifications_actives">
+                                    <?= _('Activer les notifications système par email/dashboard') ?>
+                                </label>
+                            </div>
+
+                            <button type="submit" class="btn btn-success"><i class="ph-duotone ph-floppy-disk me-2"></i><?= _('Enregistrer les paramètres') ?></button>
+                        </form>
+                    </div>
+                </div>
+
+                <!-- Password change -->
                 <div class="card">
                     <div class="card-header">
-                        <h5><?= _('Changer mon mot de passe') ?></h5>
+                        <h5><i class="ph-duotone ph-lock me-2 text-primary"></i><?= _('Changer mon mot de passe') ?></h5>
                     </div>
                     <div class="card-body">
                         <form action="/profile/update-password" method="POST">
@@ -58,5 +150,88 @@
     </div>
 </div>
 <!-- [ Main Content ] end -->
+
+<!-- Signature Pad Script -->
+<script>
+document.addEventListener("DOMContentLoaded", function() {
+    const canvas = document.getElementById('signature-pad');
+    if (!canvas) return;
+
+    const ctx = canvas.getContext('2d');
+    let drawing = false;
+
+    // Correct the canvas scale based on layout size
+    canvas.width = canvas.offsetWidth;
+    canvas.height = canvas.offsetHeight;
+
+    window.addEventListener('resize', () => {
+        // Save drawing
+        const temp = canvas.toDataURL();
+        canvas.width = canvas.offsetWidth;
+        canvas.height = canvas.offsetHeight;
+        const img = new Image();
+        img.onload = function() {
+            ctx.drawImage(img, 0, 0);
+        };
+        img.src = temp;
+    });
+
+    // Event listeners for drawing
+    canvas.addEventListener('mousedown', startDrawing);
+    canvas.addEventListener('mousemove', draw);
+    canvas.addEventListener('mouseup', stopDrawing);
+    canvas.addEventListener('mouseout', stopDrawing);
+
+    // Touch support
+    canvas.addEventListener('touchstart', (e) => {
+        const t = e.touches[0];
+        startDrawing(t);
+        e.preventDefault();
+    });
+    canvas.addEventListener('touchmove', (e) => {
+        const t = e.touches[0];
+        draw(t);
+        e.preventDefault();
+    });
+    canvas.addEventListener('touchend', () => stopDrawing());
+
+    function startDrawing(e) {
+        drawing = true;
+        ctx.beginPath();
+        ctx.moveTo(getX(e), getY(e));
+    }
+
+    function draw(e) {
+        if (!drawing) return;
+        ctx.lineWidth = 3;
+        ctx.lineCap = 'round';
+        ctx.strokeStyle = '#2c3e50';
+        ctx.lineTo(getX(e), getY(e));
+        ctx.stroke();
+    }
+
+    function stopDrawing() {
+        if (!drawing) return;
+        drawing = false;
+        document.getElementById('signature-base64').value = canvas.toDataURL('image/png');
+    }
+
+    function getX(e) {
+        const rect = canvas.getBoundingClientRect();
+        return e.clientX - rect.left;
+    }
+
+    function getY(e) {
+        const rect = canvas.getBoundingClientRect();
+        return e.clientY - rect.top;
+    }
+
+    // Clear Canvas
+    document.getElementById('clear-signature').addEventListener('click', () => {
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+        document.getElementById('signature-base64').value = '';
+    });
+});
+</script>
 
 <?php require_once __DIR__ . '/../layouts/footer_able.php'; ?>

--- a/tests/test_financial_status.php
+++ b/tests/test_financial_status.php
@@ -296,6 +296,18 @@ function setup_sqlite_db() {
         identifiant_public VARCHAR(50)
     )");
 
+    $pdo->exec("CREATE TABLE IF NOT EXISTS parametres_utilisateurs (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id INTEGER UNIQUE NOT NULL,
+        lycee_id INTEGER,
+        signature TEXT,
+        cachet TEXT,
+        langue_preferee VARCHAR(10) DEFAULT 'fr_FR',
+        theme_prefere VARCHAR(50) DEFAULT 'light',
+        notifications_actives BOOLEAN DEFAULT 1,
+        date_modification TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    )");
+
     Database::setInstance($pdo);
     return $pdo;
 }

--- a/tests/test_journal_navigation.php
+++ b/tests/test_journal_navigation.php
@@ -219,6 +219,18 @@ function init_test_db() {
         actif BOOLEAN
     )");
 
+    $pdo->exec("CREATE TABLE IF NOT EXISTS parametres_utilisateurs (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id INTEGER UNIQUE NOT NULL,
+        lycee_id INTEGER,
+        signature TEXT,
+        cachet TEXT,
+        langue_preferee VARCHAR(10) DEFAULT 'fr_FR',
+        theme_prefere VARCHAR(50) DEFAULT 'light',
+        notifications_actives BOOLEAN DEFAULT 1,
+        date_modification TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    )");
+
     Database::setInstance($pdo);
     return $pdo;
 }


### PR DESCRIPTION
- Created `parametres_utilisateurs` database table to decouple profile settings from core user data.
- Added model `ParametreUtilisateur.php` with robust CRUD and fallback logic.
- Integrated an HTML5 Canvas-based Signature Pad in the user profile view for drawing and capturing handwritten signatures as transparent PNGs.
- Handled standard image uploads for both signatures and official stamps/cachets.
- Dynamically rendered transparent signatures and stamps on payment receipts (for cashiers) and bulletins (for school directors).
- Integrated school scoping via `lycee_id` and language preferences mapping to `locale/` folders.
- Cleaned up obsolete image assets upon update to save disk space.
- Updated schema and SQLite test suites to ensure full backward compatibility.