### PR TITLE
Fix password double-hashing on profile photo updates

### DIFF
--- a/src/controllers/UserController.php
+++ b/src/controllers/UserController.php
@@ -434,6 +434,8 @@ class UserController {
                 }
 
                 $user['photo'] = $photoPath;
+                // Unset 'mot_de_passe' to prevent User::save() from re-hashing the existing password hash
+                unset($user['mot_de_passe']);
                 try {
                     User::save($user);
                     $_SESSION['user']['photo'] = $photoPath;


### PR DESCRIPTION
Unset the 'mot_de_passe' key from the user data array before calling User::save() in UserController::updatePhoto(). This prevents the general-purpose save method from re-hashing the existing password hash, resolving the post-update login lockout.