### PR TITLE
feat: integrate finance modules and fix notes menu link

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -190,6 +190,13 @@ $router->register('/depenses/pay/{id}', 'DepenseController', 'pay');
 $router->register('/depenses/process-payment/{id}', 'DepenseController', 'processPayment');
 $router->register('/depenses/cancel/{id}', 'DepenseController', 'cancel');
 
+// Gestion de la Trésorerie (Phase 2.1 & 2.2)
+$router->register('/treasury/sessions', 'SessionCaisseController', 'index');
+$router->register('/treasury/sessions/open', 'SessionCaisseController', 'open');
+$router->register('/treasury/sessions/show/{id}', 'SessionCaisseController', 'show');
+$router->register('/treasury/sessions/close', 'SessionCaisseController', 'close');
+$router->register('/treasury/sessions/approve', 'SessionCaisseController', 'approve');
+
 // Frais (Fee management)
 $router->register('/frais', 'FraisController', 'index');
 $router->register('/frais/create', 'FraisController', 'create');

--- a/src/views/layouts/sidebar_able.php
+++ b/src/views/layouts/sidebar_able.php
@@ -93,7 +93,7 @@ $navItems = [
         'condition' => Auth::get('role_name') === 'enseignant' || Auth::can('view_all', 'cahier_texte'),
     ],
     [
-        'url' => '/notes',
+        'url' => '/evaluations/select_class',
         'icon' => 'ph-duotone ph-graduation-cap',
         'text' => _('Notes'),
         'title' => _('Saisir et consulter les notes des élèves.'),
@@ -163,7 +163,7 @@ $navItems = [
     [
         'label' => _('Comptabilité'),
         'is_caption' => true,
-        'condition' => Auth::can('manage', 'paiement') || Auth::can('manage', 'salaire'),
+        'condition' => Auth::can('manage', 'paiement') || Auth::can('manage', 'salaire') || Auth::can('view', 'depense') || Auth::can('create', 'depense') || Auth::can('create', 'sessions_caisse') || Auth::can('edit', 'sessions_caisse') || Auth::can('validate', 'sessions_caisse'),
     ],
     [
         'url' => '/paiements',
@@ -171,6 +171,20 @@ $navItems = [
         'text' => _('Tableau de bord'),
         'title' => _('Tableau de bord comptable.'),
         'condition' => Auth::can('view', 'paiement'),
+    ],
+    [
+        'url' => '/treasury/sessions',
+        'icon' => 'ph-duotone ph-safe',
+        'text' => _('Sessions de caisse'),
+        'title' => _('Gérer et clôturer les sessions de caisse journalières.'),
+        'condition' => Auth::can('create', 'sessions_caisse') || Auth::can('edit', 'sessions_caisse') || Auth::can('validate', 'sessions_caisse'),
+    ],
+    [
+        'url' => '/depenses',
+        'icon' => 'ph-duotone ph-hand-coins',
+        'text' => _('Gestion des dépenses'),
+        'title' => _('Consulter et enregistrer les dépenses de l\'établissement.'),
+        'condition' => Auth::can('view', 'depense') || Auth::can('create', 'depense'),
     ],
     [
         'url' => '/settings/politique-financiere',


### PR DESCRIPTION
- Register routes for treasury/sessions de caisse in public/index.php
- Add sidebar menu items for sessions de caisse and expenses
- Expand Comptabilite parent section visibility check to include depense and sessions_caisse permissions
- Correct broken /notes sidebar link to point to /evaluations/select_class