### PR TITLE
feat(phase6): final qualification and rbac/sqlite compatibility impro…

### DIFF
--- a/src/controllers/SetupController.php
+++ b/src/controllers/SetupController.php
@@ -96,6 +96,7 @@ class SetupController {
             if ($seed_sql) {
                 if ($db->getAttribute(PDO::ATTR_DRIVER_NAME) === 'sqlite') {
                     $seed_sql = preg_replace('/ON DUPLICATE KEY UPDATE[^;]+;/i', ';', $seed_sql);
+                    $seed_sql = str_replace("\\'", "''", $seed_sql);
                 }
                 $db->exec($seed_sql);
             }

--- a/src/services/ComptabiliteService.php
+++ b/src/services/ComptabiliteService.php
@@ -126,7 +126,7 @@ class ComptabiliteService {
             ['salaire', '661000', '571000', 'Paiement salaire - Mois {ref}', 'JS'],
             ['ecart_positif', '571000', '771000', 'Régularisation écart caisse positif - Session {ref}', 'JO'],
             ['ecart_negatif', '671000', '571000', 'Régularisation écart caisse négatif - Session {ref}', 'JO'],
-            ['remise_coffre', '571100', '571200', 'Remise de fonds au Coffre Principal - Session N°{ref}', 'JO']
+            ['remise_coffre', '', '', 'Remise de fonds au Coffre Principal - Session N°{ref}', 'JO']
         ];
 
         $driver = $db->getAttribute(PDO::ATTR_DRIVER_NAME);

--- a/tests/AuthTest.php
+++ b/tests/AuthTest.php
@@ -28,8 +28,20 @@ function run_test() {
         $perm_id_stmt->execute();
         $perm_id = $perm_id_stmt->fetchColumn();
         if (!$perm_id) {
+            $db->exec("DELETE FROM role_permissions");
+            $db->exec("DELETE FROM permissions");
+            $db->exec("DELETE FROM roles");
+            $db->exec("DELETE FROM cycles");
+            $db->exec("DELETE FROM type_contrat");
+
             $seed_sql = file_get_contents(__DIR__ . '/../db/seeds.sql');
-            if ($seed_sql) $db->exec($seed_sql);
+            if ($seed_sql) {
+                if ($db->getAttribute(PDO::ATTR_DRIVER_NAME) === 'sqlite') {
+                    $seed_sql = preg_replace('/ON DUPLICATE KEY UPDATE[^;]+;/i', ';', $seed_sql);
+                    $seed_sql = str_replace("\\'", "''", $seed_sql);
+                }
+                $db->exec($seed_sql);
+            }
             $perm_id_stmt->execute();
             $perm_id = $perm_id_stmt->fetchColumn();
             if (!$perm_id) throw new Exception("Permission 'user' -> 'edit' not found in seeds.");

--- a/tests/test_admin_permissions.php
+++ b/tests/test_admin_permissions.php
@@ -23,20 +23,28 @@ function run_test() {
 
     try {
         // Clean up previous test data
-        $db->exec("DELETE FROM role_permissions WHERE role_id > 8");
+        $db->exec("DELETE FROM role_permissions");
+        $db->exec("DELETE FROM permissions");
+        $db->exec("DELETE FROM roles");
+        $db->exec("DELETE FROM cycles");
+        $db->exec("DELETE FROM type_contrat");
         $db->exec("DELETE FROM utilisateurs");
-        $db->exec("DELETE FROM roles WHERE lycee_id IS NOT NULL");
         $db->exec("DELETE FROM param_lycee");
         $db->exec("DELETE FROM annees_academiques");
         $db->exec("DELETE FROM param_general");
-
 
         // 1. Create the Lycee
         $lycee_id = Lycee::save(['nom_lycee' => 'Test Lycee', 'type_lycee' => 'prive']);
 
         // 2. Seed the database (we assume this is already done, but we need the roles)
         $seed_sql = file_get_contents(__DIR__ . '/../db/seeds.sql');
-        if ($seed_sql) $db->exec($seed_sql);
+        if ($seed_sql) {
+            if ($db->getAttribute(PDO::ATTR_DRIVER_NAME) === 'sqlite') {
+                $seed_sql = preg_replace('/ON DUPLICATE KEY UPDATE[^;]+;/i', ';', $seed_sql);
+                $seed_sql = str_replace("\\'", "''", $seed_sql);
+            }
+            $db->exec($seed_sql);
+        }
 
         // 3. Create a specific admin role for this Lycee
         Role::save(['nom_role' => 'Admin - Test Lycee', 'lycee_id' => $lycee_id]);


### PR DESCRIPTION
…vements

- Updated default schemas_comptables to have NULL/empty placeholder accounts for remise_coffre, enforcing dynamic resolution.
- Sanitized db/seeds.sql loading logic under SQLite to handle backslash single quote escaping.
- Cleaned up database tables prior to seeding in tests to ensure perfect test isolation.