### PR TITLE
fix(drh): resolve SQLSTATE[HY093] duplicate PDO parameter binding in …

### DIFF
--- a/src/services/AuthorizationScopeService.php
+++ b/src/services/AuthorizationScopeService.php
@@ -89,12 +89,13 @@ class AuthorizationScopeService {
             FROM personnel_cycles_assignments
             WHERE personnel_id = :personnel_id
               AND actif = 1
-              AND date_debut <= :today
-              AND (date_fin IS NULL OR date_fin >= :today)
+              AND date_debut <= :today_start
+              AND (date_fin IS NULL OR date_fin >= :today_end)
         ");
         $stmt->execute([
             'personnel_id' => $user_id,
-            'today' => $today
+            'today_start' => $today,
+            'today_end' => $today
         ]);
 
         $cycle_ids = array_map('intval', $stmt->fetchAll(PDO::FETCH_COLUMN)) ?: [];

--- a/src/services/PersonnelContractService.php
+++ b/src/services/PersonnelContractService.php
@@ -34,12 +34,12 @@ class PersonnelContractService {
             JOIN type_contrat tc ON pch.type_contrat_id = tc.id_contrat
             WHERE pch.personnel_id = :personnel_id
               AND pch.statut_contrat = 'actif'
-              AND pch.date_debut <= :today
-              AND (pch.date_fin IS NULL OR pch.date_fin >= :today)
+              AND pch.date_debut <= :today_start
+              AND (pch.date_fin IS NULL OR pch.date_fin >= :today_end)
             ORDER BY pch.date_debut DESC
             LIMIT 1
         ");
-        $stmt->execute(['personnel_id' => $personnel_id, 'today' => $today]);
+        $stmt->execute(['personnel_id' => $personnel_id, 'today_start' => $today, 'today_end' => $today]);
         $res = $stmt->fetch(PDO::FETCH_ASSOC);
         return $res ?: null;
     }


### PR DESCRIPTION
…scope queries

Disambiguate reused :today PDO placeholders in AuthorizationScopeService and PersonnelContractService by renaming them to :today_start and :today_end. This fixes SQLSTATE[HY093] parameter binding mismatch errors on DRH dashboard and annuaire routes while preserving 100% of scope and security checks.