### PR TITLE
fix(paie): align table collation in Migration 13 to resolve MariaDB e…

### DIFF
--- a/db/migrations/20240115_13_create_lot2_paie_engine.php
+++ b/db/migrations/20240115_13_create_lot2_paie_engine.php
@@ -7,7 +7,7 @@ function migrate_13($db) {
 
     $pk_int = $isSqlite ? "INTEGER PRIMARY KEY AUTOINCREMENT" : "INT AUTO_INCREMENT PRIMARY KEY";
     $pk_bigint = $isSqlite ? "INTEGER PRIMARY KEY AUTOINCREMENT" : "BIGINT AUTO_INCREMENT PRIMARY KEY";
-    $fk_ref = $isSqlite ? "" : "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci";
+    $fk_ref = $isSqlite ? "" : "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4";
 
     // 1. paie_periodes
     $sql_periodes = $isSqlite ? "


### PR DESCRIPTION
…rrno 150

Aligns $fk_ref table definition in db/migrations/20240115_13_create_lot2_paie_engine.php to ENGINE=InnoDB DEFAULT CHARSET=utf8mb4, matching all previous migrations (01-12) and preventing foreign key constraint errors (errno 150) on paie_cahier_texte_validations and other Lot 2.1 tables.