### PR TITLE
Fix contract-driven valuation and estimation in Paie Cahier de Texte

### DIFF
--- a/src/models/PaieCahierTexteValidation.php
+++ b/src/models/PaieCahierTexteValidation.php
@@ -55,20 +55,35 @@ class PaieCahierTexteValidation {
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }
 
-    public static function resolveContractHourlyRate(int $personnelId): float {
-        $db = Database::getInstance();
-        $stmt = $db->prepare("
-            SELECT cc.valeur_numerique
-            FROM personnel_contrats_historique c
-            JOIN personnel_contrat_composants cc ON c.id = cc.contrat_id
-            WHERE c.personnel_id = :personnel_id
-              AND c.statut_contrat = 'actif'
-              AND (cc.nature_composant = 'taux_horaire' OR cc.code_composant = 'TAUX_HORAIRE' OR cc.unite_remuneration = 'heure')
-            ORDER BY cc.id DESC LIMIT 1
-        ");
-        $stmt->execute(['personnel_id' => $personnelId]);
-        $val = $stmt->fetchColumn();
-        return ($val !== false && (float)$val > 0) ? (float)$val : 5000.00;
+    public static function resolveContractHourlyRate(int $personnelId, ?string $dateRef = null): float {
+        require_once __DIR__ . '/../services/PersonnelContractService.php';
+        $contract = PersonnelContractService::getActiveContract($personnelId, $dateRef);
+        if (!$contract) {
+            return 0.00;
+        }
+
+        if (!empty($contract['composants'])) {
+            foreach ($contract['composants'] as $cc) {
+                $nat = strtolower($cc['nature_composant'] ?? '');
+                $code = strtoupper($cc['code_composant'] ?? '');
+                $unite = strtolower($cc['unite_remuneration'] ?? '');
+                if ($nat === 'taux_horaire' || $code === 'TAUX_HORAIRE' || $unite === 'heure') {
+                    $val = (float)($cc['valeur_numerique'] ?? 0);
+                    if ($val > 0) {
+                        return $val;
+                    }
+                }
+            }
+        }
+
+        if (($contract['mode_calcul_principal'] ?? '') === 'taux_horaire' || ($contract['unite_remuneration'] ?? '') === 'heure') {
+            $base = (float)($contract['salaire_base'] ?? 0);
+            if ($base > 0) {
+                return $base;
+            }
+        }
+
+        return 0.00;
     }
 
     public static function validateSession(int $cahierId, int $userId, ?float $tauxHoraire = null): int {
@@ -95,7 +110,7 @@ class PaieCahierTexteValidation {
         $cycleId = $stmtCl->fetchColumn() ?: null;
 
         if ($tauxHoraire === null || $tauxHoraire <= 0) {
-            $tauxHoraire = self::resolveContractHourlyRate((int)$cahier['personnel_id']);
+            $tauxHoraire = self::resolveContractHourlyRate((int)$cahier['personnel_id'], $cahier['date_cours'] ?? null);
         }
 
         $existing = self::findByCahierId($cahierId);
@@ -146,6 +161,7 @@ class PaieCahierTexteValidation {
 
     public static function getTeacherHoursMetrics(array $context): array {
         $db = Database::getInstance();
+        require_once __DIR__ . '/../services/PersonnelContractService.php';
 
         $lyceeId = $context['lycee_id'] ?? null;
         $teacherId = !empty($context['teacher_id']) ? (int)$context['teacher_id'] : null;
@@ -156,9 +172,16 @@ class PaieCahierTexteValidation {
         $serie = !empty($context['serie']) ? trim($context['serie']) : null;
         $numero = (isset($context['numero']) && $context['numero'] !== '') ? trim($context['numero']) : null;
 
+        $dateRef = $context['date_debut'] ?? date('Y-m-d');
+        $contract = $teacherId ? PersonnelContractService::getActiveContract($teacherId, $dateRef) : null;
+
+        $modeRemuneration = $contract['mode_calcul_principal'] ?? ($contract['type_paiement'] ?? 'forfait_fixe');
+        $salaireBase = (float)($contract['salaire_base'] ?? 0.0);
+        $tauxHoraireContractuel = $teacherId ? self::resolveContractHourlyRate($teacherId, $dateRef) : 0.0;
+
         // 1. Calculate Realized Hours directly from cahier_texte
         $sqlReal = "
-            SELECT ct.heure_debut, ct.heure_fin
+            SELECT ct.date_cours, ct.heure_debut, ct.heure_fin, ct.personnel_id
             FROM cahier_texte ct
             LEFT JOIN classes cl ON ct.classe_id = cl.id_classe
             WHERE 1=1
@@ -212,23 +235,28 @@ class PaieCahierTexteValidation {
         $rowsReal = $stmtReal->fetchAll(PDO::FETCH_ASSOC);
 
         $heuresRealisees = 0.0;
+        $valorisationRealiseeVariable = 0.0;
+
         foreach ($rowsReal as $r) {
+            $dh = 2.0;
             if (!empty($r['heure_debut']) && !empty($r['heure_fin'])) {
                 $t1 = strtotime($r['heure_debut']);
                 $t2 = strtotime($r['heure_fin']);
                 if ($t2 > $t1) {
-                    $heuresRealisees += ($t2 - $t1) / 3600.0;
-                } else {
-                    $heuresRealisees += 2.0;
+                    $dh = ($t2 - $t1) / 3600.0;
                 }
-            } else {
-                $heuresRealisees += 2.0;
             }
+            $heuresRealisees += $dh;
+
+            $pId = (int)($r['personnel_id'] ?? $teacherId);
+            $thDate = $pId ? self::resolveContractHourlyRate($pId, $r['date_cours']) : 0.0;
+            $valorisationRealiseeVariable += ($dh * $thDate);
         }
 
         // 2. Calculate Validated / Paid Hours
         $sqlVal = "
-            SELECT v.id, v.duree_heures, v.taux_horaire, v.statut_validation,
+            SELECT v.id, v.cahier_id, v.duree_heures, v.taux_horaire, v.statut_validation,
+                   c.date_cours, c.personnel_id,
                    MAX(CASE WHEN b.est_version_active = 1 THEN 1 ELSE 0 END) as est_paye
             FROM paie_cahier_texte_validations v
             JOIN cahier_texte c ON v.cahier_id = c.cahier_id
@@ -272,7 +300,16 @@ class PaieCahierTexteValidation {
             $sqlVal .= " AND cl.numero = :numero";
             $paramsVal['numero'] = $numero;
         }
-        $sqlVal .= " GROUP BY v.id, v.duree_heures, v.taux_horaire, v.statut_validation";
+        if (!empty($context['date_debut'])) {
+            $sqlVal .= " AND c.date_cours >= :date_debut";
+            $paramsVal['date_debut'] = $context['date_debut'];
+        }
+        if (!empty($context['date_fin'])) {
+            $sqlVal .= " AND c.date_cours <= :date_fin";
+            $paramsVal['date_fin'] = $context['date_fin'];
+        }
+
+        $sqlVal .= " GROUP BY v.id, v.cahier_id, v.duree_heures, v.taux_horaire, v.statut_validation, c.date_cours, c.personnel_id";
 
         $stmtVal = $db->prepare($sqlVal);
         $stmtVal->execute($paramsVal);
@@ -281,7 +318,7 @@ class PaieCahierTexteValidation {
         $heuresValidees = 0.0;
         $heuresRefusees = 0.0;
         $heuresPayees = 0.0;
-        $montantEstime = 0.0;
+        $valorisationValideeVariable = 0.0;
         $montantPaye = 0.0;
 
         foreach ($rowsVal as $rv) {
@@ -289,7 +326,7 @@ class PaieCahierTexteValidation {
             $th = (float)$rv['taux_horaire'];
             if ($rv['statut_validation'] === 'valide') {
                 $heuresValidees += $dh;
-                $montantEstime += ($dh * $th);
+                $valorisationValideeVariable += ($dh * $th);
                 if (!empty($rv['est_paye'])) {
                     $heuresPayees += $dh;
                     $montantPaye += ($dh * $th);
@@ -301,13 +338,33 @@ class PaieCahierTexteValidation {
 
         $heuresAConsolider = max(0.0, $heuresValidees - $heuresPayees);
 
+        if (!$teacherId) {
+            $valorisationRealiseeEstimee = $valorisationRealiseeVariable;
+            $valorisationValidee = $valorisationValideeVariable;
+            $modeRemuneration = 'multi_enseignants';
+        } elseif ($modeRemuneration === 'forfait_fixe') {
+            $valorisationRealiseeEstimee = $salaireBase;
+            $valorisationValidee = $salaireBase;
+        } elseif ($modeRemuneration === 'mixte') {
+            $valorisationRealiseeEstimee = $salaireBase + $valorisationRealiseeVariable;
+            $valorisationValidee = $salaireBase + $valorisationValideeVariable;
+        } else {
+            $valorisationRealiseeEstimee = $valorisationRealiseeVariable;
+            $valorisationValidee = $valorisationValideeVariable;
+        }
+
         return [
             'heures_realisees' => round($heuresRealisees, 2),
             'heures_validees' => round($heuresValidees, 2),
             'heures_refusees' => round($heuresRefusees, 2),
             'heures_payees' => round($heuresPayees, 2),
             'heures_a_consolider' => round($heuresAConsolider, 2),
-            'montant_estime' => round($montantEstime, 2),
+            'mode_remuneration' => $modeRemuneration,
+            'salaire_base_contractuel' => round($salaireBase, 2),
+            'taux_horaire_contractuel' => round($tauxHoraireContractuel, 2),
+            'valorisation_realisee_estimee' => round($valorisationRealiseeEstimee, 2),
+            'valorisation_validee' => round($valorisationValidee, 2),
+            'montant_estime' => round($valorisationValidee > 0 ? $valorisationValidee : $valorisationRealiseeEstimee, 2),
             'montant_paye' => round($montantPaye, 2)
         ];
     }

--- a/src/services/PersonnelContractService.php
+++ b/src/services/PersonnelContractService.php
@@ -117,10 +117,10 @@ class PersonnelContractService {
             LEFT JOIN type_contrat tc ON pch.type_contrat_id = tc.id_contrat
             LEFT JOIN paie_entites_juridiques pej ON pch.entite_juridique_id = pej.id
             WHERE pch.personnel_id = :personnel_id
-              AND pch.statut_contrat = 'actif'
+              AND pch.statut_contrat IN ('actif', 'avenant_remplace')
               AND pch.date_debut <= :date_ref1
               AND (pch.date_fin IS NULL OR pch.date_fin >= :date_ref2)
-            ORDER BY pch.date_debut DESC
+            ORDER BY pch.date_debut DESC, pch.version_num DESC
             LIMIT 1
         ");
         $stmt->execute([

--- a/src/views/paie/cahier_texte/index.php
+++ b/src/views/paie/cahier_texte/index.php
@@ -249,14 +249,17 @@ $searchMode = $searchMode ?? 'pedagogique';
         </div>
         <div class="col-md-2 col-6">
           <div class="card border-0 shadow-sm text-center py-2">
-            <span class="text-muted small fw-bold text-uppercase"><?= _("Montant estimé") ?></span>
-            <h5 class="mb-0 text-dark font-monospace"><?= number_format($metrics['montant_estime'], 0, ',', ' ') ?> FCFA</h5>
+            <span class="text-muted small fw-bold text-uppercase"><?= _("Valorisation estimée") ?></span>
+            <h5 class="mb-0 text-dark font-monospace"><?= number_format($metrics['valorisation_realisee_estimee'], 0, ',', ' ') ?> FCFA</h5>
+            <span class="text-muted extra-small" style="font-size: 10px;">
+              <?= $metrics['mode_remuneration'] === 'forfait_fixe' ? _("Fixe mensuel") : ($metrics['mode_remuneration'] === 'mixte' ? _("Fixe + Heures") : _("Service réalisé")) ?>
+            </span>
           </div>
         </div>
         <div class="col-md-2 col-6">
           <div class="card border-0 shadow-sm text-center py-2">
-            <span class="text-success small fw-bold text-uppercase"><?= _("Montant payé") ?></span>
-            <h5 class="mb-0 text-success font-monospace"><?= number_format($metrics['montant_paye'], 0, ',', ' ') ?> FCFA</h5>
+            <span class="text-success small fw-bold text-uppercase"><?= _("Valorisation validée") ?></span>
+            <h5 class="mb-0 text-success font-monospace"><?= number_format($metrics['valorisation_validee'], 0, ',', ' ') ?> FCFA</h5>
           </div>
         </div>
       </div>
@@ -310,7 +313,10 @@ $searchMode = $searchMode ?? 'pedagogique';
                   <tr>
                     <td colspan="8" class="text-center py-5 text-muted">
                       <i class="ph-duotone ph-clock-afternoon fs-1 d-block mb-2 text-muted"></i>
-                      <?= _("Aucune séance de cours trouvée pour les critères sélectionnés.") ?>
+                      <div><?= _("Aucune séance du Cahier de Texte ne correspond à la période de paie sélectionnée.") ?></div>
+                      <a href="?search_mode=<?= htmlspecialchars($searchMode) ?>&periode_id=all" class="btn btn-sm btn-link-primary mt-2">
+                        <i class="ph-duotone ph-calendar me-1"></i> <?= _("Voir les séances de toutes les périodes") ?>
+                      </a>
                     </td>
                   </tr>
                 <?php else: ?>

--- a/tests/Lot21PaieModuleTest.php
+++ b/tests/Lot21PaieModuleTest.php
@@ -52,6 +52,7 @@ $db->exec("DELETE FROM cahier_texte");
 $db->exec("DELETE FROM classes");
 $db->exec("DELETE FROM cycles");
 $db->exec("DELETE FROM matieres");
+$db->exec("DELETE FROM personnel_contrats_historique WHERE personnel_id >= 100");
 
 // Seed initial environment
 $db->exec("INSERT INTO param_lycee (id, nom_lycee) VALUES (1, 'Lycée Test Paie') ON CONFLICT DO NOTHING");
@@ -175,6 +176,61 @@ echo "\n--- TEST 12: Conformité i18n et RTL ---\n";
 $translatedLabel = _("Validations des Heures Pédagogiques - Cahier de Texte");
 assert_test(!empty($translatedLabel), "Traduction i18n fonctionnelle: '$translatedLabel'");
 
+// --- TEST 13: Mode Fixe Mensuel (Non-transformé en Heures x 5000) ---
+echo "\n--- TEST 13: Fixe Mensuel (Préservation du salaire contractuel de base) ---\n";
+$db->exec("INSERT INTO utilisateurs (id_user, lycee_id, nom, prenom, identifiant_public, email, mot_de_passe, role_id, actif) VALUES (103, 1, 'Sow', 'Mamadou', '103ENS', 'mamadou@test.com', 'hash', 6, 1) ON CONFLICT DO NOTHING");
+$db->exec("INSERT INTO personnel_contrats_historique (id, personnel_id, type_contrat_id, date_debut, entite_juridique_id, mode_calcul_principal, salaire_base, devise, statut_contrat, version_num) VALUES (203, 103, 1, '2024-01-01', 1, 'forfait_fixe', 300000.00, 'FCFA', 'actif', 1) ON CONFLICT DO NOTHING");
+
+$metricsFixe = PaieCahierTexteValidation::getTeacherHoursMetrics([
+    'lycee_id' => 1,
+    'teacher_id' => 103,
+    'date_debut' => '2024-09-01',
+    'date_fin' => '2024-09-30'
+]);
+assert_test((float)$metricsFixe['valorisation_realisee_estimee'] == 300000.00, "Un enseignant fixe mensuel affiche sa rémunération contractuelle (300 000 FCFA) et non un calcul fictif à l'heure");
+
+// --- TEST 14: Absence de Fallback 5000 FCFA ---
+echo "\n--- TEST 14: Zéro Fallback Hardcodé (0.00 si non configuré) ---\n";
+$rateZero = PaieCahierTexteValidation::resolveContractHourlyRate(103, '2024-09-01');
+assert_test($rateZero === 0.00, "Le système retourne 0.00 et n'invente jamais 5000.00 FCFA pour un contrat sans composant horaire");
+
+// --- TEST 15: Avenant avec Date d'Effet (Pondération Datée par Séance) ---
+echo "\n--- TEST 15: Avenant avec Date d'Effet ---\n";
+$db->exec("INSERT INTO utilisateurs (id_user, lycee_id, nom, prenom, identifiant_public, email, mot_de_passe, role_id, actif) VALUES (104, 1, 'Diallo', 'Aissatou', '104ENS', 'aissatou@test.com', 'hash', 6, 1) ON CONFLICT DO NOTHING");
+// Contrat V1 (01/09 -> 14/09): Taux = 4000 FCFA
+$db->exec("INSERT INTO personnel_contrats_historique (id, personnel_id, type_contrat_id, date_debut, date_fin, entite_juridique_id, mode_calcul_principal, salaire_base, devise, statut_contrat, version_num) VALUES (204, 104, 1, '2024-09-01', '2024-09-14', 1, 'taux_horaire', 4000.00, 'FCFA', 'avenant_remplace', 1) ON CONFLICT DO NOTHING");
+// Avenant V2 (15/09 -> 30/09): Taux = 5000 FCFA
+$db->exec("INSERT INTO personnel_contrats_historique (id, personnel_id, type_contrat_id, date_debut, date_fin, entite_juridique_id, mode_calcul_principal, salaire_base, devise, statut_contrat, version_num) VALUES (205, 104, 1, '2024-09-15', NULL, 1, 'taux_horaire', 5000.00, 'FCFA', 'actif', 2) ON CONFLICT DO NOTHING");
+
+$rateBefore = PaieCahierTexteValidation::resolveContractHourlyRate(104, '2024-09-05');
+$rateAfter = PaieCahierTexteValidation::resolveContractHourlyRate(104, '2024-09-20');
+
+assert_test($rateBefore === 4000.00 && $rateAfter === 5000.00, "Chaque séance est valorisée au taux contractuel actif à sa date réelle (4000 FCFA le 05/09 vs 5000 FCFA le 20/09)");
+
+// --- TEST 16: Valorisation Estimée AVANT et APRÈS Validation ---
+echo "\n--- TEST 16: Estimation AVANT et APRÈS Validation ---\n";
+$db->exec("INSERT INTO cahier_texte (cahier_id, lycee_id, personnel_id, classe_id, matiere_id, date_cours, heure_debut, heure_fin, contenu_cours) VALUES (305, 1, 104, 10, 1, '2024-09-05', '08:00:00', '12:00:00', 'Cours 1') ON CONFLICT DO NOTHING"); // 4h x 4000 = 16000
+$db->exec("INSERT INTO cahier_texte (cahier_id, lycee_id, personnel_id, classe_id, matiere_id, date_cours, heure_debut, heure_fin, contenu_cours) VALUES (306, 1, 104, 10, 1, '2024-09-20', '08:00:00', '12:00:00', 'Cours 2') ON CONFLICT DO NOTHING"); // 4h x 5000 = 20000
+
+$metricsBeforeVal = PaieCahierTexteValidation::getTeacherHoursMetrics([
+    'lycee_id' => 1,
+    'teacher_id' => 104,
+    'date_debut' => '2024-09-01',
+    'date_fin' => '2024-09-30'
+]);
+assert_test((float)$metricsBeforeVal['valorisation_realisee_estimee'] == 36000.00 && (float)$metricsBeforeVal['heures_validees'] == 0.00, "AVANT validation: Valorisation estimée du service réalisé = 36 000 FCFA (16k + 20k)");
+
+PaieCahierTexteValidation::validateSession(305, 1);
+PaieCahierTexteValidation::validateSession(306, 1);
+
+$metricsAfterVal = PaieCahierTexteValidation::getTeacherHoursMetrics([
+    'lycee_id' => 1,
+    'teacher_id' => 104,
+    'date_debut' => '2024-09-01',
+    'date_fin' => '2024-09-30'
+]);
+assert_test((float)$metricsAfterVal['valorisation_validee'] == 36000.00 && (float)$metricsAfterVal['heures_validees'] == 8.00, "APRÈS validation: Valorisation validée = 36 000 FCFA sur 8.0h validées");
+
 echo "\n=========================================================================\n";
-echo "🏆 TOUS LES 12 TESTS D'INTÉGRATION ET DE SÉCURITÉ V6.1.1 ONT RÉUSSI !\n";
+echo "🏆 TOUS LES 16 TESTS D'INTÉGRATION ET DE SÉCURITÉ V6.1.2 ONT RÉUSSI !\n";
 echo "=========================================================================\n";


### PR DESCRIPTION
- Remove hardcoded 5000 FCFA fallback rate in PaieCahierTexteValidation
- Resolve contract rates by session date using PersonnelContractService
- Support fixed monthly, hourly, and mixed compensation contract modes
- Calculate estimated valuation before and after session validation
- Include contract amendments with status avenant_remplace on date lookup
- Add integration tests for all contract valuation scenarios